### PR TITLE
feat(chroniques): surlignage de passages pour modifications futures

### DIFF
--- a/pages/lore-chroniques.html
+++ b/pages/lore-chroniques.html
@@ -552,6 +552,373 @@
     .chron-mode-toggle #chron-mode-label { display: none; }
     .chron-fs-toggle { display: none; }   /* déjà fullscreen par défaut */
 }
+
+/* ── Surlignages (highlights) ─────────────────────────────── */
+.chron-highlight {
+    background-color: rgba(255, 220, 80, 0.40);
+    color: inherit;
+    padding: 0.05em 0;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background-color .15s, box-shadow .15s;
+}
+.chron-highlight.color-yellow { background-color: rgba(255, 220, 80, 0.40); }
+.chron-highlight.color-yellow:hover { background-color: rgba(255, 220, 80, 0.60); }
+.chron-highlight.color-red { background-color: rgba(220, 80, 80, 0.32); }
+.chron-highlight.color-red:hover { background-color: rgba(220, 80, 80, 0.50); }
+.chron-highlight.color-green { background-color: rgba(120, 200, 100, 0.32); }
+.chron-highlight.color-green:hover { background-color: rgba(120, 200, 100, 0.50); }
+.chron-highlight.color-blue { background-color: rgba(80, 150, 220, 0.32); }
+.chron-highlight.color-blue:hover { background-color: rgba(80, 150, 220, 0.50); }
+.chron-highlight[data-has-note="1"]::after {
+    content: '\1F4DD';
+    font-size: 0.7em;
+    vertical-align: super;
+    margin-left: 1px;
+    opacity: 0.75;
+}
+.chron-highlight.flash {
+    box-shadow: 0 0 0 2px var(--gold);
+    transition: box-shadow .3s;
+}
+
+/* Floating selection toolbar */
+.chron-select-toolbar {
+    position: fixed;
+    z-index: 9500;
+    background: var(--bg-mid);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    padding: 5px 7px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+    transform: translate(-50%, -100%);
+    margin-top: -8px;
+}
+.chron-select-toolbar[hidden] { display: none; }
+.chron-color-btn {
+    width: 22px;
+    height: 22px;
+    border: 1px solid rgba(0, 0, 0, 0.25);
+    border-radius: 50%;
+    cursor: pointer;
+    padding: 0;
+    transition: transform .15s;
+}
+.chron-color-btn:hover { transform: scale(1.15); }
+.chron-color-btn[data-color="yellow"] { background: rgba(255, 220, 80, 0.85); }
+.chron-color-btn[data-color="red"]    { background: rgba(220, 80, 80, 0.85); }
+.chron-color-btn[data-color="green"]  { background: rgba(120, 200, 100, 0.85); }
+.chron-color-btn[data-color="blue"]   { background: rgba(80, 150, 220, 0.85); }
+.chron-select-note-btn {
+    background: transparent;
+    border: none;
+    color: var(--gold);
+    cursor: pointer;
+    font-size: 1rem;
+    padding: 2px 6px;
+    line-height: 1;
+}
+.chron-select-note-btn:hover { opacity: 0.75; }
+
+/* Highlight context menu */
+.chron-highlight-menu {
+    position: fixed;
+    z-index: 9500;
+    background: var(--bg-mid);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.35);
+    min-width: 200px;
+    transform: translate(-50%, -100%);
+    margin-top: -8px;
+}
+.chron-highlight-menu[hidden] { display: none; }
+.chron-highlight-menu-colors {
+    display: flex;
+    gap: 6px;
+    justify-content: center;
+    padding: 2px 0;
+}
+.chron-highlight-menu-btn {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 4px;
+    padding: 5px 8px;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 0.8rem;
+    font-family: 'Raleway', sans-serif;
+    text-align: left;
+}
+.chron-highlight-menu-btn:hover { background: var(--gold-dim); color: var(--gold); }
+.chron-highlight-menu-note {
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    padding: 5px 7px;
+    background: var(--panel-bg);
+    border-radius: 4px;
+    max-height: 80px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    line-height: 1.4;
+}
+
+/* Highlights side panel */
+.chron-highlights-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 380px;
+    max-width: 90vw;
+    background: var(--bg-mid);
+    border-left: 1px solid var(--panel-border);
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform .3s ease;
+    box-shadow: -4px 0 20px rgba(0, 0, 0, 0.25);
+}
+.chron-highlights-panel.open { transform: translateX(0); }
+.chron-highlights-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.8rem 1rem;
+    border-bottom: 1px solid var(--panel-border);
+    flex-shrink: 0;
+}
+.chron-highlights-title {
+    font-family: 'Cinzel', serif;
+    color: var(--gold);
+    font-size: 1rem;
+}
+.chron-highlights-actions { display: flex; gap: 6px; align-items: center; }
+.chron-highlights-actions button {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 4px;
+    padding: 4px 8px;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-family: 'Raleway', sans-serif;
+}
+.chron-highlights-actions button:hover { background: var(--gold-dim); color: var(--gold); }
+.chron-highlights-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--panel-border);
+    flex-shrink: 0;
+}
+.chron-highlights-tab {
+    flex: 1;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    padding: 8px;
+    cursor: pointer;
+    font-family: 'Raleway', sans-serif;
+    font-size: 0.82rem;
+    border-bottom: 2px solid transparent;
+}
+.chron-highlights-tab.active { color: var(--gold); border-bottom-color: var(--gold); }
+.chron-highlights-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.6rem;
+}
+.chron-highlights-empty {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 2rem 1rem;
+    font-style: italic;
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+.chron-highlight-item {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+    padding: 0.55rem 0.7rem;
+    margin-bottom: 0.5rem;
+    font-family: 'Raleway', sans-serif;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: border-color .15s, box-shadow .15s;
+}
+.chron-highlight-item:hover { border-color: var(--gold); box-shadow: 0 2px 10px rgba(122, 76, 10, 0.15); }
+.chron-highlight-item-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 4px;
+}
+.chron-highlight-item-chapter {
+    font-family: 'Cinzel', serif;
+    font-size: 0.72rem;
+    color: var(--gold);
+    letter-spacing: 0.5px;
+}
+.chron-highlight-item-color {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
+    vertical-align: middle;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+}
+.chron-highlight-item-text {
+    color: var(--text);
+    line-height: 1.5;
+    font-size: 0.85rem;
+    border-left: 3px solid transparent;
+    padding: 0.15rem 0 0.15rem 0.55rem;
+    margin: 0.25rem 0;
+}
+.chron-highlight-item.color-yellow .chron-highlight-item-text { border-left-color: rgba(255, 220, 80, 0.85); }
+.chron-highlight-item.color-red    .chron-highlight-item-text { border-left-color: rgba(220, 80, 80, 0.85); }
+.chron-highlight-item.color-green  .chron-highlight-item-text { border-left-color: rgba(120, 200, 100, 0.85); }
+.chron-highlight-item.color-blue   .chron-highlight-item-text { border-left-color: rgba(80, 150, 220, 0.85); }
+.chron-highlight-item-note {
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    padding: 0.3rem 0.5rem;
+    margin-top: 0.3rem;
+    background: rgba(0, 0, 0, 0.18);
+    border-radius: 3px;
+    white-space: pre-wrap;
+    line-height: 1.45;
+}
+.chron-highlight-item-actions {
+    display: flex;
+    gap: 6px;
+    margin-top: 0.4rem;
+    justify-content: flex-end;
+}
+.chron-highlight-item-actions button {
+    background: transparent;
+    border: 1px solid var(--panel-border);
+    border-radius: 3px;
+    color: var(--text-muted);
+    cursor: pointer;
+    font-size: 0.7rem;
+    padding: 2px 7px;
+    font-family: 'Raleway', sans-serif;
+}
+.chron-highlight-item-actions button:hover { color: var(--gold); border-color: var(--gold); }
+
+/* Note dialog */
+.chron-note-dialog {
+    position: fixed;
+    inset: 0;
+    z-index: 9600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+}
+.chron-note-dialog[hidden] { display: none; }
+.chron-note-dialog-panel {
+    background: var(--bg-mid);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    padding: 1.2rem;
+    width: 90vw;
+    max-width: 460px;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+}
+.chron-note-dialog-title {
+    font-family: 'Cinzel', serif;
+    color: var(--gold);
+    font-size: 1rem;
+    margin-bottom: 0.6rem;
+}
+.chron-note-dialog-snippet {
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-bottom: 0.8rem;
+    line-height: 1.4;
+    padding: 0.4rem 0.6rem;
+    background: var(--panel-bg);
+    border-left: 3px solid var(--gold);
+    border-radius: 3px;
+    max-height: 110px;
+    overflow-y: auto;
+}
+.chron-note-dialog-textarea {
+    width: 100%;
+    min-height: 110px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 4px;
+    color: var(--text);
+    padding: 0.55rem;
+    font-family: 'Raleway', sans-serif;
+    font-size: 0.9rem;
+    resize: vertical;
+    box-sizing: border-box;
+    line-height: 1.5;
+}
+.chron-note-dialog-textarea:focus { outline: 1px solid var(--gold); border-color: var(--gold); }
+.chron-note-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 0.8rem;
+}
+.chron-note-dialog-actions button {
+    font-family: 'Raleway', sans-serif;
+    font-size: 0.85rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 4px;
+    border: 1px solid var(--panel-border);
+    background: var(--panel-bg);
+    color: var(--text);
+    cursor: pointer;
+}
+.chron-note-dialog-actions button.primary {
+    background: var(--gold-dim);
+    color: var(--gold);
+    border-color: var(--gold);
+}
+.chron-note-dialog-actions button:hover { opacity: 0.85; }
+
+/* Topbar highlights toggle */
+.chron-highlights-toggle {
+    font-family: 'Raleway', sans-serif;
+    font-size: 0.8rem;
+    padding: 0.35rem 0.55rem;
+    border: 1px solid var(--panel-border);
+    border-radius: var(--radius);
+    background: var(--panel-bg);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background .15s, color .15s, border-color .15s;
+    flex-shrink: 0;
+    margin-left: .4rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.chron-highlights-toggle:hover { background: var(--gold-dim); color: var(--gold); border-color: var(--gold); }
+.chron-highlights-toggle.has-items { color: var(--gold); border-color: var(--gold); }
+
+@media (max-width: 768px) {
+    .chron-highlights-toggle { font-size: 0.7rem; padding: 0.3rem 0.4rem; }
+    .chron-highlights-panel { width: 100%; max-width: 100%; }
+}
 </style>
 
 <div id="chroniques-root">
@@ -572,6 +939,9 @@
             <button class="chron-mode-toggle chron-fs-toggle" id="chron-fs-toggle" aria-label="Plein écran" title="Plein écran">
                 <span class="chron-mode-icon" id="chron-fs-icon">⛶</span>
             </button>
+            <button class="chron-highlights-toggle" id="chron-highlights-toggle" aria-label="Surlignages" title="Voir les surlignages">
+                <span aria-hidden="true">📝</span><span id="chron-highlights-count"></span>
+            </button>
             <button class="chron-modal-nav-btn" id="chron-next-btn">Suivant &rarr;</button>
             <button class="chron-modal-close" id="chron-close-btn" aria-label="Fermer">&times;</button>
         </div>
@@ -587,6 +957,55 @@
                 <span id="chron-progress-pos">Chapitre 1/40</span>
                 <span id="chron-progress-day">Jour 1</span>
             </div>
+        </div>
+        <aside class="chron-highlights-panel" id="chron-highlights-panel" aria-label="Liste des surlignages">
+            <div class="chron-highlights-header">
+                <div class="chron-highlights-title">Surlignages</div>
+                <div class="chron-highlights-actions">
+                    <button id="chron-highlights-export" title="Exporter en JSON">Export</button>
+                    <button id="chron-highlights-close" title="Fermer">×</button>
+                </div>
+            </div>
+            <div class="chron-highlights-tabs">
+                <button class="chron-highlights-tab active" data-tab="chapter">Ce chapitre</button>
+                <button class="chron-highlights-tab" data-tab="all">Tous</button>
+            </div>
+            <div class="chron-highlights-list" id="chron-highlights-list"></div>
+        </aside>
+    </div>
+</div>
+
+<!-- Selection toolbar (highlight creator) -->
+<div id="chron-select-toolbar" class="chron-select-toolbar" hidden>
+    <button class="chron-color-btn" data-color="yellow" title="Surligner — jaune (général)" aria-label="Surligner en jaune"></button>
+    <button class="chron-color-btn" data-color="red" title="Surligner — rouge (à modifier)" aria-label="Surligner en rouge"></button>
+    <button class="chron-color-btn" data-color="green" title="Surligner — vert (vérifié)" aria-label="Surligner en vert"></button>
+    <button class="chron-color-btn" data-color="blue" title="Surligner — bleu (à explorer)" aria-label="Surligner en bleu"></button>
+    <button class="chron-select-note-btn" id="chron-select-note-btn" title="Surligner avec une note" aria-label="Ajouter une note">📝</button>
+</div>
+
+<!-- Highlight context menu (when clicking an existing highlight) -->
+<div id="chron-highlight-menu" class="chron-highlight-menu" hidden>
+    <div class="chron-highlight-menu-note" id="chron-hl-menu-note" hidden></div>
+    <div class="chron-highlight-menu-colors">
+        <button class="chron-color-btn" data-color="yellow" aria-label="Jaune"></button>
+        <button class="chron-color-btn" data-color="red" aria-label="Rouge"></button>
+        <button class="chron-color-btn" data-color="green" aria-label="Vert"></button>
+        <button class="chron-color-btn" data-color="blue" aria-label="Bleu"></button>
+    </div>
+    <button class="chron-highlight-menu-btn" id="chron-hl-menu-edit-note">📝 Note</button>
+    <button class="chron-highlight-menu-btn" id="chron-hl-menu-delete">🗑️ Supprimer</button>
+</div>
+
+<!-- Note dialog -->
+<div id="chron-note-dialog" class="chron-note-dialog" hidden>
+    <div class="chron-note-dialog-panel">
+        <div class="chron-note-dialog-title">Note de modification</div>
+        <div class="chron-note-dialog-snippet" id="chron-note-dialog-snippet"></div>
+        <textarea class="chron-note-dialog-textarea" id="chron-note-dialog-textarea" placeholder="Ex. : reformuler la phrase, vérifier la date du voyage, ajouter le nom de la nation…"></textarea>
+        <div class="chron-note-dialog-actions">
+            <button id="chron-note-dialog-cancel">Annuler</button>
+            <button id="chron-note-dialog-save" class="primary">Enregistrer</button>
         </div>
     </div>
 </div>
@@ -861,6 +1280,9 @@
         }
 
         pagesWrapper.innerHTML = '<div class="chron-md-content">' + audioHtml + html + '</div>';
+
+        // Apply persisted highlights for this chapter (before pagination so columns are stable)
+        applyAllHighlightsForCurrentChapter();
 
         var bookmark = loadBookmark();
         var sameChapter = bookmark && allChapters[currentChapterIdx]
@@ -1149,6 +1571,10 @@
                 else if (document.webkitExitFullscreen) document.webkitExitFullscreen();
             } catch(e) {}
         }
+        hideSelectToolbar();
+        hideHlMenu();
+        closeHlPanel();
+        closeNoteDialog();
         modal.setAttribute('hidden', '');
         document.body.style.overflow = '';
         currentChapterIdx = -1;
@@ -1213,6 +1639,547 @@
                 }
             });
         }
+    }
+
+    // ── Highlights system ────────────────────────────────────
+    var STORAGE_KEY_HL = 'hybelior_chroniques_highlights';
+    var HL_COLORS = ['yellow', 'red', 'green', 'blue'];
+    var DEFAULT_HL_COLOR = 'yellow';
+
+    var selectToolbar   = document.getElementById('chron-select-toolbar');
+    var selectNoteBtn   = document.getElementById('chron-select-note-btn');
+    var hlMenu          = document.getElementById('chron-highlight-menu');
+    var hlMenuNote      = document.getElementById('chron-hl-menu-note');
+    var hlMenuEditNote  = document.getElementById('chron-hl-menu-edit-note');
+    var hlMenuDelete    = document.getElementById('chron-hl-menu-delete');
+    var hlPanel         = document.getElementById('chron-highlights-panel');
+    var hlList          = document.getElementById('chron-highlights-list');
+    var hlToggleBtn     = document.getElementById('chron-highlights-toggle');
+    var hlCloseBtn      = document.getElementById('chron-highlights-close');
+    var hlExportBtn     = document.getElementById('chron-highlights-export');
+    var hlCountSpan     = document.getElementById('chron-highlights-count');
+    var hlTabs          = hlPanel ? hlPanel.querySelectorAll('.chron-highlights-tab') : [];
+    var noteDialog      = document.getElementById('chron-note-dialog');
+    var noteDlgSnippet  = document.getElementById('chron-note-dialog-snippet');
+    var noteDlgTextarea = document.getElementById('chron-note-dialog-textarea');
+    var noteDlgSave     = document.getElementById('chron-note-dialog-save');
+    var noteDlgCancel   = document.getElementById('chron-note-dialog-cancel');
+
+    var pendingSelection = null;       // { range, start, end, text } pour création
+    var activeHighlightId = null;      // pour menu contextuel
+    var noteDialogContext = null;      // 'create' | 'edit'
+    var noteDialogPending = null;      // { start, end, text } | highlightObj
+    var hlPanelTab = 'chapter';        // 'chapter' | 'all'
+
+    function loadHighlights() {
+        try {
+            var raw = localStorage.getItem(STORAGE_KEY_HL);
+            return raw ? JSON.parse(raw) : [];
+        } catch(e) { return []; }
+    }
+    function saveHighlights(arr) {
+        try { localStorage.setItem(STORAGE_KEY_HL, JSON.stringify(arr)); } catch(e) {}
+    }
+    function getCurrentChapterHighlights() {
+        if (currentChapterIdx < 0) return [];
+        var ch = allChapters[currentChapterIdx];
+        if (!ch) return [];
+        return loadHighlights().filter(function(h) { return h.chapterNum === ch.num; });
+    }
+    function getContentEl() {
+        return pagesWrapper ? pagesWrapper.querySelector('.chron-md-content') : null;
+    }
+    function genHlId() {
+        return 'h_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 7);
+    }
+
+    // Range -> plain-text offsets within container
+    function rangeToOffsets(range, container) {
+        var pre = document.createRange();
+        pre.selectNodeContents(container);
+        pre.setEnd(range.startContainer, range.startOffset);
+        var start = pre.toString().length;
+        var end = start + range.toString().length;
+        return { start: start, end: end };
+    }
+
+    // Plain-text offsets -> Range within container
+    function offsetsToRange(start, end, container) {
+        var range = document.createRange();
+        var charIndex = 0, foundStart = false;
+        var walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null);
+        var node;
+        while ((node = walker.nextNode())) {
+            var nodeLen = node.nodeValue.length;
+            var next = charIndex + nodeLen;
+            if (!foundStart && start >= charIndex && start <= next) {
+                range.setStart(node, start - charIndex);
+                foundStart = true;
+            }
+            if (foundStart && end >= charIndex && end <= next) {
+                range.setEnd(node, end - charIndex);
+                return range;
+            }
+            charIndex = next;
+        }
+        return null;
+    }
+
+    // Wrap a range with <mark> elements (per text node, to handle element boundaries)
+    function wrapRangeWithMark(range, highlight) {
+        if (range.collapsed) return [];
+        var marks = [];
+        var startContainer = range.startContainer;
+        var endContainer = range.endContainer;
+        var startOffset = range.startOffset;
+        var endOffset = range.endOffset;
+
+        var common = range.commonAncestorContainer;
+        if (common.nodeType === Node.TEXT_NODE) common = common.parentNode;
+
+        var nodes = [];
+        var walker = document.createTreeWalker(common, NodeFilter.SHOW_TEXT, {
+            acceptNode: function(n) {
+                try { return range.intersectsNode(n) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT; }
+                catch(e) { return NodeFilter.FILTER_REJECT; }
+            }
+        });
+        var n;
+        while ((n = walker.nextNode())) nodes.push(n);
+
+        nodes.forEach(function(node) {
+            var nr = document.createRange();
+            nr.selectNodeContents(node);
+            if (node === startContainer) nr.setStart(node, startOffset);
+            if (node === endContainer)   nr.setEnd(node, endOffset);
+            if (nr.collapsed) return;
+            var mark = document.createElement('mark');
+            mark.className = 'chron-highlight color-' + (highlight.color || DEFAULT_HL_COLOR);
+            mark.setAttribute('data-highlight-id', highlight.id);
+            if (highlight.note) mark.setAttribute('data-has-note', '1');
+            try {
+                nr.surroundContents(mark);
+                marks.push(mark);
+            } catch(e) { /* skip nodes that can't be wrapped */ }
+        });
+        return marks;
+    }
+
+    function applyHighlight(highlight) {
+        var content = getContentEl();
+        if (!content) return;
+        if (content.querySelector('mark[data-highlight-id="' + highlight.id + '"]')) return;
+        var range = offsetsToRange(highlight.start, highlight.end, content);
+        if (!range) {
+            // Fallback : recherche du snippet en texte brut
+            var plain = content.textContent || '';
+            var idx = plain.indexOf(highlight.text || '');
+            if (idx === -1 || !highlight.text) return;
+            range = offsetsToRange(idx, idx + highlight.text.length, content);
+            if (!range) return;
+        }
+        wrapRangeWithMark(range, highlight);
+    }
+
+    function applyAllHighlightsForCurrentChapter() {
+        var hls = getCurrentChapterHighlights();
+        // Tri par start desc : on enveloppe d'abord les plus tardifs pour
+        // ne pas perturber les offsets des plus précoces (les wrappers
+        // ajoutent des nœuds DOM mais conservent le textContent).
+        hls.sort(function(a, b) { return b.start - a.start; });
+        hls.forEach(applyHighlight);
+        updateHighlightsCount();
+    }
+
+    function createHighlight(start, end, text, color, note) {
+        if (currentChapterIdx < 0) return null;
+        var ch = allChapters[currentChapterIdx];
+        if (!ch) return null;
+        var hl = {
+            id: genHlId(),
+            chapterNum: ch.num,
+            chapterTitle: ch.titre,
+            start: start,
+            end: end,
+            text: text,
+            color: color || DEFAULT_HL_COLOR,
+            note: note || '',
+            timestamp: Date.now()
+        };
+        var arr = loadHighlights();
+        arr.push(hl);
+        saveHighlights(arr);
+        return hl;
+    }
+
+    function updateHighlight(id, patch) {
+        var arr = loadHighlights();
+        var idx = -1;
+        for (var i = 0; i < arr.length; i++) { if (arr[i].id === id) { idx = i; break; } }
+        if (idx === -1) return null;
+        for (var k in patch) { if (Object.prototype.hasOwnProperty.call(patch, k)) arr[idx][k] = patch[k]; }
+        saveHighlights(arr);
+        var marks = document.querySelectorAll('mark[data-highlight-id="' + id + '"]');
+        marks.forEach(function(m) {
+            HL_COLORS.forEach(function(c) { m.classList.remove('color-' + c); });
+            m.classList.add('color-' + (arr[idx].color || DEFAULT_HL_COLOR));
+            if (arr[idx].note) m.setAttribute('data-has-note', '1');
+            else m.removeAttribute('data-has-note');
+        });
+        if (hlPanel && hlPanel.classList.contains('open')) renderHighlightsList();
+        return arr[idx];
+    }
+
+    function deleteHighlight(id) {
+        var arr = loadHighlights().filter(function(h) { return h.id !== id; });
+        saveHighlights(arr);
+        var marks = document.querySelectorAll('mark[data-highlight-id="' + id + '"]');
+        marks.forEach(function(m) {
+            var parent = m.parentNode;
+            while (m.firstChild) parent.insertBefore(m.firstChild, m);
+            parent.removeChild(m);
+            parent.normalize();
+        });
+        updateHighlightsCount();
+        if (hlPanel && hlPanel.classList.contains('open')) renderHighlightsList();
+        if (readMode === 'page') rePaginate();
+    }
+
+    function updateHighlightsCount() {
+        if (!hlCountSpan) return;
+        var n = getCurrentChapterHighlights().length;
+        hlCountSpan.textContent = n > 0 ? ' ' + n : '';
+        if (hlToggleBtn) hlToggleBtn.classList.toggle('has-items', n > 0);
+    }
+
+    // ── Selection toolbar ─────────────────────────────────
+    function showSelectToolbar(rect) {
+        if (!selectToolbar) return;
+        var x = rect.left + rect.width / 2;
+        var y = rect.top;
+        // Clamp horizontally to viewport
+        var margin = 80;
+        x = Math.max(margin, Math.min(window.innerWidth - margin, x));
+        if (y < 60) y = rect.bottom + 50; // not enough room above → place below
+        selectToolbar.style.left = x + 'px';
+        selectToolbar.style.top = y + 'px';
+        selectToolbar.removeAttribute('hidden');
+    }
+    function hideSelectToolbar() {
+        if (selectToolbar) selectToolbar.setAttribute('hidden', '');
+        pendingSelection = null;
+    }
+
+    function onSelectionChange() {
+        if (!modal || modal.hasAttribute('hidden')) { hideSelectToolbar(); return; }
+        var content = getContentEl();
+        if (!content) { hideSelectToolbar(); return; }
+        var sel = window.getSelection();
+        if (!sel || sel.isCollapsed || sel.rangeCount === 0) { hideSelectToolbar(); return; }
+        var range = sel.getRangeAt(0);
+        if (!content.contains(range.startContainer) || !content.contains(range.endContainer)) {
+            hideSelectToolbar();
+            return;
+        }
+        // Skip selections inside the audio block
+        var sp = range.startContainer.parentElement;
+        if (sp && sp.closest('.chron-audio-block')) { hideSelectToolbar(); return; }
+        var text = sel.toString();
+        if (!text || !text.trim()) { hideSelectToolbar(); return; }
+        var offsets = rangeToOffsets(range, content);
+        pendingSelection = { range: range.cloneRange(), start: offsets.start, end: offsets.end, text: text };
+        var rect = range.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) { hideSelectToolbar(); return; }
+        showSelectToolbar(rect);
+    }
+    document.addEventListener('selectionchange', onSelectionChange);
+
+    if (selectToolbar) {
+        selectToolbar.querySelectorAll('.chron-color-btn').forEach(function(btn) {
+            btn.addEventListener('mousedown', function(e) { e.preventDefault(); });
+            btn.addEventListener('click', function() {
+                if (!pendingSelection) return;
+                var hl = createHighlight(pendingSelection.start, pendingSelection.end, pendingSelection.text, btn.dataset.color, '');
+                if (hl) applyHighlight(hl);
+                if (window.getSelection) window.getSelection().removeAllRanges();
+                hideSelectToolbar();
+                updateHighlightsCount();
+                if (readMode === 'page') rePaginate();
+            });
+        });
+    }
+    if (selectNoteBtn) {
+        selectNoteBtn.addEventListener('mousedown', function(e) { e.preventDefault(); });
+        selectNoteBtn.addEventListener('click', function() {
+            if (!pendingSelection) return;
+            openNoteDialog('create', null, pendingSelection.text);
+        });
+    }
+
+    // ── Highlight context menu ────────────────────────────
+    function showHlMenu(rect, highlight) {
+        activeHighlightId = highlight.id;
+        if (hlMenuNote) {
+            if (highlight.note) {
+                hlMenuNote.textContent = highlight.note;
+                hlMenuNote.removeAttribute('hidden');
+            } else {
+                hlMenuNote.setAttribute('hidden', '');
+            }
+        }
+        var x = rect.left + rect.width / 2;
+        var y = rect.top;
+        var margin = 110;
+        x = Math.max(margin, Math.min(window.innerWidth - margin, x));
+        if (y < 100) y = rect.bottom + 60;
+        hlMenu.style.left = x + 'px';
+        hlMenu.style.top = y + 'px';
+        hlMenu.removeAttribute('hidden');
+    }
+    function hideHlMenu() {
+        if (hlMenu) hlMenu.setAttribute('hidden', '');
+        activeHighlightId = null;
+    }
+
+    document.addEventListener('click', function(e) {
+        var mark = e.target.closest && e.target.closest('mark.chron-highlight');
+        if (mark && pagesWrapper && pagesWrapper.contains(mark)) {
+            e.stopPropagation();
+            var id = mark.getAttribute('data-highlight-id');
+            var hl = loadHighlights().find(function(h) { return h.id === id; });
+            if (!hl) return;
+            var rect = mark.getBoundingClientRect();
+            showHlMenu(rect, hl);
+            return;
+        }
+        if (hlMenu && !hlMenu.contains(e.target)) hideHlMenu();
+    });
+
+    if (hlMenu) {
+        hlMenu.querySelectorAll('.chron-color-btn').forEach(function(btn) {
+            btn.addEventListener('click', function(e) {
+                e.stopPropagation();
+                if (!activeHighlightId) return;
+                updateHighlight(activeHighlightId, { color: btn.dataset.color });
+                hideHlMenu();
+            });
+        });
+    }
+    if (hlMenuEditNote) {
+        hlMenuEditNote.addEventListener('click', function(e) {
+            e.stopPropagation();
+            if (!activeHighlightId) return;
+            var hl = loadHighlights().find(function(h) { return h.id === activeHighlightId; });
+            if (!hl) return;
+            openNoteDialog('edit', hl, hl.text);
+            hideHlMenu();
+        });
+    }
+    if (hlMenuDelete) {
+        hlMenuDelete.addEventListener('click', function(e) {
+            e.stopPropagation();
+            if (!activeHighlightId) return;
+            if (!confirm('Supprimer ce surlignage ?')) return;
+            deleteHighlight(activeHighlightId);
+            hideHlMenu();
+        });
+    }
+
+    // ── Note dialog ───────────────────────────────────────
+    function openNoteDialog(mode, highlight, snippet) {
+        noteDialogContext = mode;
+        if (mode === 'create') {
+            noteDialogPending = pendingSelection ? {
+                start: pendingSelection.start,
+                end: pendingSelection.end,
+                text: pendingSelection.text
+            } : null;
+            if (noteDlgTextarea) noteDlgTextarea.value = '';
+        } else if (mode === 'edit') {
+            noteDialogPending = highlight;
+            if (noteDlgTextarea) noteDlgTextarea.value = (highlight && highlight.note) || '';
+        }
+        if (noteDlgSnippet) noteDlgSnippet.textContent = snippet || '';
+        if (noteDialog) noteDialog.removeAttribute('hidden');
+        setTimeout(function() { if (noteDlgTextarea) noteDlgTextarea.focus(); }, 30);
+    }
+    function closeNoteDialog() {
+        if (noteDialog) noteDialog.setAttribute('hidden', '');
+        noteDialogContext = null;
+        noteDialogPending = null;
+    }
+    if (noteDlgCancel) noteDlgCancel.addEventListener('click', closeNoteDialog);
+    if (noteDlgSave) {
+        noteDlgSave.addEventListener('click', function() {
+            var note = (noteDlgTextarea && noteDlgTextarea.value || '').trim();
+            if (noteDialogContext === 'create') {
+                if (!noteDialogPending) { closeNoteDialog(); return; }
+                var hl = createHighlight(noteDialogPending.start, noteDialogPending.end, noteDialogPending.text, DEFAULT_HL_COLOR, note);
+                if (hl) applyHighlight(hl);
+                if (window.getSelection) window.getSelection().removeAllRanges();
+                hideSelectToolbar();
+                updateHighlightsCount();
+                if (readMode === 'page') rePaginate();
+            } else if (noteDialogContext === 'edit') {
+                if (noteDialogPending) updateHighlight(noteDialogPending.id, { note: note });
+            }
+            closeNoteDialog();
+        });
+    }
+    if (noteDialog) {
+        noteDialog.addEventListener('click', function(e) {
+            if (e.target === noteDialog) closeNoteDialog();
+        });
+    }
+
+    // ── Highlights side panel ─────────────────────────────
+    function openHlPanel() {
+        if (!hlPanel) return;
+        hlPanel.classList.add('open');
+        renderHighlightsList();
+    }
+    function closeHlPanel() {
+        if (hlPanel) hlPanel.classList.remove('open');
+    }
+    if (hlToggleBtn) {
+        hlToggleBtn.addEventListener('click', function() {
+            if (hlPanel.classList.contains('open')) closeHlPanel();
+            else openHlPanel();
+        });
+    }
+    if (hlCloseBtn) hlCloseBtn.addEventListener('click', closeHlPanel);
+    hlTabs.forEach(function(tab) {
+        tab.addEventListener('click', function() {
+            hlTabs.forEach(function(t) { t.classList.remove('active'); });
+            tab.classList.add('active');
+            hlPanelTab = tab.dataset.tab;
+            renderHighlightsList();
+        });
+    });
+
+    function colorSwatch(color) {
+        switch (color) {
+            case 'red':   return 'rgba(220, 80, 80, 0.85)';
+            case 'green': return 'rgba(120, 200, 100, 0.85)';
+            case 'blue':  return 'rgba(80, 150, 220, 0.85)';
+            default:      return 'rgba(255, 220, 80, 0.85)';
+        }
+    }
+    function truncateText(s, n) {
+        s = s || '';
+        return s.length > n ? s.slice(0, n) + '…' : s;
+    }
+
+    function renderHighlightsList() {
+        if (!hlList) return;
+        var all = loadHighlights();
+        var items;
+        if (hlPanelTab === 'chapter') {
+            var ch = allChapters[currentChapterIdx];
+            items = ch ? all.filter(function(h) { return h.chapterNum === ch.num; }) : [];
+        } else {
+            items = all.slice();
+        }
+        items.sort(function(a, b) {
+            if (a.chapterNum !== b.chapterNum) return a.chapterNum - b.chapterNum;
+            return a.start - b.start;
+        });
+        if (items.length === 0) {
+            var msg = hlPanelTab === 'chapter'
+                ? 'Aucun surlignage sur ce chapitre.<br><small>Sélectionne un passage du texte pour le surligner.</small>'
+                : 'Aucun surlignage enregistré.<br><small>Sélectionne un passage pour le marquer en vue d’une modification future.</small>';
+            hlList.innerHTML = '<div class="chron-highlights-empty">' + msg + '</div>';
+            return;
+        }
+        var html = '';
+        items.forEach(function(h) {
+            html += '<div class="chron-highlight-item color-' + (h.color || DEFAULT_HL_COLOR) + '" data-id="' + h.id + '" data-chapter="' + h.chapterNum + '">';
+            html += '<div class="chron-highlight-item-header">';
+            html += '<span class="chron-highlight-item-color" style="background:' + colorSwatch(h.color) + '"></span>';
+            html += '<span class="chron-highlight-item-chapter">Chapitre ' + h.chapterNum + ' — ' + escHtml(h.chapterTitle || '') + '</span>';
+            html += '</div>';
+            html += '<div class="chron-highlight-item-text">' + escHtml(truncateText(h.text, 240)) + '</div>';
+            if (h.note) html += '<div class="chron-highlight-item-note">' + escHtml(h.note) + '</div>';
+            html += '<div class="chron-highlight-item-actions">';
+            html += '<button data-action="note">' + (h.note ? 'Modifier la note' : 'Ajouter une note') + '</button>';
+            html += '<button data-action="delete">Supprimer</button>';
+            html += '</div>';
+            html += '</div>';
+        });
+        hlList.innerHTML = html;
+        hlList.querySelectorAll('.chron-highlight-item').forEach(function(item) {
+            item.addEventListener('click', function(e) {
+                var action = e.target && e.target.dataset && e.target.dataset.action;
+                var id = item.dataset.id;
+                var h = loadHighlights().find(function(x) { return x.id === id; });
+                if (!h) return;
+                if (action === 'delete') {
+                    e.stopPropagation();
+                    if (!confirm('Supprimer ce surlignage ?')) return;
+                    deleteHighlight(id);
+                    return;
+                }
+                if (action === 'note') {
+                    e.stopPropagation();
+                    openNoteDialog('edit', h, h.text);
+                    return;
+                }
+                jumpToHighlight(h);
+            });
+        });
+    }
+
+    function jumpToHighlight(h) {
+        var doScroll = function() {
+            var attempts = 0;
+            var tryScroll = function() {
+                attempts++;
+                var mark = document.querySelector('mark[data-highlight-id="' + h.id + '"]');
+                if (!mark && attempts < 20) { setTimeout(tryScroll, 100); return; }
+                if (!mark) return;
+                if (readMode === 'scroll') {
+                    mark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                } else if (readMode === 'page') {
+                    var content = getContentEl();
+                    if (!content) return;
+                    var w = pagesWrapper.clientWidth;
+                    var contentRect = content.getBoundingClientRect();
+                    var markRect = mark.getBoundingClientRect();
+                    var match = /translate3d\(([-\d.]+)px/.exec(content.style.transform || '');
+                    var currentX = match ? parseFloat(match[1]) : 0;
+                    var leftInContent = (markRect.left - contentRect.left) - currentX;
+                    var page = Math.floor(leftInContent / w);
+                    gotoPage(Math.max(0, Math.min(totalPages - 1, page)));
+                }
+                mark.classList.add('flash');
+                setTimeout(function() { mark.classList.remove('flash'); }, 1500);
+            };
+            tryScroll();
+        };
+        if (currentChapterIdx >= 0 && allChapters[currentChapterIdx] && allChapters[currentChapterIdx].num === h.chapterNum) {
+            doScroll();
+        } else {
+            openChapter(h.chapterNum);
+            setTimeout(doScroll, 250);
+        }
+    }
+
+    if (hlExportBtn) {
+        hlExportBtn.addEventListener('click', function() {
+            var arr = loadHighlights();
+            if (!arr.length) { alert('Aucun surlignage à exporter.'); return; }
+            var json = JSON.stringify(arr, null, 2);
+            var blob = new Blob([json], { type: 'application/json' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a');
+            a.href = url;
+            var date = new Date().toISOString().slice(0, 10);
+            a.download = 'chroniques-surlignages-' + date + '.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
     }
 
     // ── Utility ──────────────────────────────────────────────


### PR DESCRIPTION
## Résumé

Ajoute la possibilité de **surligner des passages** dans le lecteur de la chronique de Sorin Valthen, avec **notes de modification attachées**, afin de marquer ce qui devra être retravaillé plus tard.

## Fonctionnalités

- **Sélection → barre flottante** avec 4 couleurs (jaune = général, rouge = à modifier, vert = vérifié, bleu = à explorer) + bouton "📝" pour surligner avec une note immédiatement.
- **Clic sur un surlignage existant** → menu contextuel : changer la couleur, éditer la note, supprimer.
- **Persistance** dans `localStorage` (clé `hybelior_chroniques_highlights`) — les surlignages sont restaurés à la prochaine ouverture du chapitre, robustes aux variantes mineures du texte (offsets + repli sur recherche du snippet).
- **Panneau latéral** (bouton 📝 dans la topbar du lecteur) listant les surlignages :
  - Onglet *Ce chapitre* / *Tous*
  - Aperçu, note, code couleur, titre du chapitre
  - Clic = saute au passage (compatible mode défilement et mode pages)
  - Bouton **Export** → téléchargement JSON pour réutilisation hors-site
- Compatible avec le **mode pages** (e-reader) : la pagination est recalculée après ajout/suppression.
- Compteur de surlignages visible dans la topbar quand le chapitre en contient.

## Test plan

- [ ] Ouvrir un chapitre, sélectionner un passage → la barre de couleurs apparaît
- [ ] Cliquer sur une couleur → le passage est surligné, persiste après refresh
- [ ] Cliquer sur un surlignage → menu (changer couleur, note, supprimer)
- [ ] Bouton 📝 (sélection) → ouvre la modale de note ; saisie + Enregistrer crée un surlignage avec note
- [ ] Bouton 📝 dans la topbar → panneau latéral : onglet *Ce chapitre*, *Tous*, jump-to, suppression
- [ ] Vérifier en mode *Pages* que le saut au surlignage va à la bonne page
- [ ] Vérifier sur mobile (sélection tactile + barre flottante)
- [ ] Bouton *Export* → téléchargement d'un JSON contenant tous les surlignages


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx62FPLbQGwnZG8XH1KpTd)_