### PR TITLE
feat(nation): page dédiée par nation + sidebar groupée par continent

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -361,8 +361,11 @@ body {
     min-width: 0;
 }
 
-/* Carte : pleine largeur, sidebar masquée */
-.site-layout:has(.page-carte) .site-sidebar { display: none; }
+/* Carte : pleine largeur, sidebar masquée (et son toggle mobile aussi) */
+.site-layout:has(.page-carte) .site-sidebar,
+.site-layout:has(.page-carte) ~ * .sidebar-toggle,
+.site-layout:has(.page-carte) .sidebar-toggle,
+.site-layout:has(.page-carte) .sidebar-backdrop { display: none; }
 .page-container.page-carte { display: flex; align-items: stretch; }
 .page-container.page-carte .page-content {
     max-width: none;
@@ -3675,31 +3678,115 @@ select:focus-visible,
     }
 }
 
+/* ── Sidebar drawer (mobile) — bouton toggle + backdrop, masqués en desktop ── */
+.sidebar-toggle,
+.sidebar-close,
+.sidebar-backdrop { display: none; }
+
 /* ── Responsive ── */
 @media (max-width: 768px) {
-    /* Sidebar globale — bascule en horizontal en haut */
+    /* Sidebar globale — bascule en drawer latéral coulissant */
     .site-layout { flex-direction: column; }
+
     .site-sidebar {
-        width: 100%;
-        position: static;
-        height: auto;
-        max-height: 220px;
-        border-right: none;
-        border-bottom: 1px solid rgba(120, 78, 18, 0.18);
-        padding: 12px 16px;
-        overflow-y: hidden;
-        overflow-x: auto;
-    }
-    .site-sidebar .subtab-nav {
-        flex-direction: row;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-        gap: 4px;
-        padding-bottom: 0;
+        position: fixed;
+        top: var(--nav-height);
+        left: 0;
+        width: min(86vw, 320px);
+        height: calc(100vh - var(--nav-height));
+        max-height: none;
+        padding: 50px 16px 32px;
+        border-right: 1px solid rgba(120, 78, 18, 0.28);
         border-bottom: none;
-        margin-bottom: 0;
+        overflow-y: auto;
+        overflow-x: hidden;
+        z-index: 30;
+        transform: translateX(-100%);
+        transition: transform 0.22s ease;
+        background: rgba(232, 222, 200, 0.98);
     }
-    .site-sidebar .subtab-btn { white-space: nowrap; }
+    body.sidebar-open .site-sidebar {
+        transform: translateX(0);
+        box-shadow: 6px 0 24px rgba(40, 24, 4, 0.25);
+    }
+
+    /* Backdrop pour fermeture au tap */
+    .sidebar-backdrop {
+        display: block;
+        position: fixed;
+        inset: var(--nav-height) 0 0 0;
+        background: rgba(20, 12, 4, 0.45);
+        z-index: 20;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.18s ease;
+    }
+    body.sidebar-open .sidebar-backdrop {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    /* Bouton hamburger flottant — visible quand le sidebar est utile */
+    .sidebar-toggle {
+        display: flex;
+        align-items: center;
+        gap: 7px;
+        position: fixed;
+        top: calc(var(--nav-height) + 8px);
+        left: 10px;
+        z-index: 25;
+        padding: 7px 12px 7px 10px;
+        background: rgba(232, 222, 200, 0.95);
+        border: 1px solid rgba(120, 78, 18, 0.30);
+        border-radius: 20px;
+        color: var(--gold, #7a4c0a);
+        font-family: 'Cinzel', serif;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 1.4px;
+        text-transform: uppercase;
+        cursor: pointer;
+        box-shadow: 0 2px 10px rgba(40, 24, 4, 0.18);
+    }
+    .sidebar-toggle-icon {
+        display: inline-block;
+        width: 14px;
+        height: 10px;
+        background:
+            linear-gradient(currentColor, currentColor) 0 0/100% 2px no-repeat,
+            linear-gradient(currentColor, currentColor) 0 50%/100% 2px no-repeat,
+            linear-gradient(currentColor, currentColor) 0 100%/100% 2px no-repeat;
+    }
+    body.sidebar-open .sidebar-toggle { display: none; }
+
+    /* Bouton fermer dans la sidebar */
+    .sidebar-close {
+        display: block;
+        position: absolute;
+        top: 6px;
+        right: 6px;
+        width: 32px;
+        height: 32px;
+        font-size: 22px;
+        line-height: 28px;
+        background: transparent;
+        border: 1px solid rgba(120, 78, 18, 0.25);
+        border-radius: 50%;
+        color: var(--gold, #7a4c0a);
+        cursor: pointer;
+    }
+
+    /* Subtab-nav reste vertical dans le drawer */
+    .site-sidebar .subtab-nav {
+        flex-direction: column;
+        gap: 3px;
+        padding-bottom: 12px;
+        margin-bottom: 12px;
+        border-bottom: 1px solid rgba(120, 78, 18, 0.18);
+    }
+    .site-sidebar .subtab-btn { text-align: left; white-space: normal; }
+
+    /* TOC reste cachée sur mobile pour ne pas alourdir le drawer */
     .site-sidebar .toc-list,
     .site-sidebar .toc-progress,
     .site-sidebar .toc-title { display: none; }
@@ -3716,6 +3803,10 @@ select:focus-visible,
     .toc-list, .toc-progress, .toc-progress-label, .toc-title { display: none; }
     .subtab-content { padding-left: 0; border-left: none; }
     .hist-continent-grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+
+    /* Le quick-nav lore est utile en mobile pour accéder aux nations — on
+       l'affiche normalement dans le drawer. */
+    .sidebar-lore-nav { display: block; }
 }
 
 /* ===== Footer ===== */
@@ -4324,11 +4415,10 @@ select:focus-visible,
 }
 
 @media (max-width: 768px) {
-    /* Sur mobile, le sidebar bascule en bandeau horizontal (cf. règle existante).
-       Le quick-nav prend trop de place dans ce mode — on le cache et on garde
-       le subtab-nav existant. L'utilisateur peut toujours retourner à la page
-       Lore landing via le top-nav. */
-    .sidebar-lore-nav { display: none; }
+    /* Sur mobile, le sidebar devient un drawer coulissant (cf. règles plus haut).
+       Le quick-nav y reste visible — c'est même son intérêt principal en mobile
+       puisque les nations/continents ne sont accessibles que par là. */
+    .sidebar-lore-nav { display: block; }
 }
 
 /* ============================================================

--- a/css/style.css
+++ b/css/style.css
@@ -4332,6 +4332,89 @@ select:focus-visible,
 }
 
 /* ============================================================
+   NATION PAGE — page dédiée par nation (#nation/<slug>)
+   ============================================================ */
+
+.nation-page {
+    max-width: 980px;
+    margin: 0 auto;
+}
+.nation-page-crumbs {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-muted, #6a5438);
+    margin-bottom: 12px;
+}
+.nation-page-back {
+    color: var(--gold, #7a4c0a);
+    text-decoration: none;
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    border-bottom: 1px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+}
+.nation-page-back:hover {
+    color: var(--gold-bright, #a86c1c);
+    border-bottom-color: currentColor;
+}
+.nation-page-crumbs-sep { opacity: 0.5; }
+.nation-page-continent {
+    font-family: var(--font-title, 'Cinzel', serif);
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    font-size: 11px;
+    color: var(--text-muted, #6a5438);
+}
+.nation-page-title {
+    font-family: var(--font-title, 'Cinzel', serif);
+    color: var(--gold, #7a4c0a);
+    font-size: 32px;
+    letter-spacing: 2px;
+    margin: 0 0 18px;
+    border: none;
+    padding: 0;
+}
+.nation-page-tabs {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid rgba(120, 78, 18, 0.22);
+    margin-bottom: 24px;
+}
+.nation-page-tab {
+    font-family: 'Raleway', sans-serif;
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+    padding: 10px 18px;
+    border: none;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: var(--text-muted, #6a5438);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+    margin-bottom: -1px;
+}
+.nation-page-tab:hover { color: var(--gold, #7a4c0a); }
+.nation-page-tab.active {
+    color: var(--gold, #7a4c0a);
+    border-bottom-color: var(--gold, #7a4c0a);
+}
+.nation-page-body {
+    padding-top: 8px;
+}
+.nation-page-loading,
+.nation-page-error {
+    padding: 24px;
+    text-align: center;
+    color: var(--text-muted, #6a5438);
+    font-style: italic;
+}
+.nation-page-error { color: #884030; }
+
+/* ============================================================
    MD HUB TABS — bandelette de sous-pages pour les pages-hubs
    ============================================================ */
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,13 @@
 </nav>
 
 <div class="site-layout">
+    <button id="sidebar-toggle" class="sidebar-toggle" aria-label="Ouvrir le menu latéral" aria-expanded="false" aria-controls="site-sidebar">
+        <span class="sidebar-toggle-icon" aria-hidden="true"></span>
+        <span class="sidebar-toggle-label">Menu</span>
+    </button>
+    <div id="sidebar-backdrop" class="sidebar-backdrop"></div>
     <aside id="site-sidebar" class="site-sidebar">
+        <button class="sidebar-close" id="sidebar-close" aria-label="Fermer le menu">&times;</button>
         <div id="lore-search-wrapper" class="lore-search-wrapper" style="display:none;">
             <input type="text" id="lore-search-input" class="lore-search-input" placeholder="Rechercher nation, ville…" autocomplete="off">
             <div id="lore-search-results" class="lore-search-results"></div>

--- a/js/lore-reader.js
+++ b/js/lore-reader.js
@@ -173,11 +173,20 @@ function renderMarkdown(container, text) {
 
 // ── Event delegation ──────────────────────────────────────────
 document.addEventListener('click', e => {
-    // Nation links (delegated — lore.html may not be loaded yet)
+    // Nation links (delegated — lore.html may not be loaded yet).
+    // Si la nation a une page dédiée (#nation/<slug>), on navigue ; sinon modal.
     const nationLink = e.target.closest('.nation-link');
     if (nationLink) {
         e.preventDefault();
-        openLoreModal(nationLink.dataset.nation);
+        const name = nationLink.dataset.nation;
+        if (window.NavConfig && typeof NavConfig.slugifyNation === 'function') {
+            const slug = NavConfig.slugifyNation(name);
+            if (NavConfig.findNationBySlug(slug)) {
+                window.location.hash = 'nation/' + slug;
+                return;
+            }
+        }
+        openLoreModal(name);
         return;
     }
 

--- a/js/lore-search.js
+++ b/js/lore-search.js
@@ -44,21 +44,35 @@ var LoreSearch = (function() {
     }
 
     function openNation(loreIndexName) {
+        // Résout vers un nom de nation canonique connu de NATIONS, puis navigue
+        // vers la page dédiée #nation/<slug>.
+        var resolved = null;
         if (window.LoreReader && window.LoreReader.NATIONS) {
-            // Direct match
             if (window.LoreReader.NATIONS[loreIndexName]) {
-                window.LoreReader.open(loreIndexName);
-                return;
-            }
-            // Fuzzy: lore-index names may differ from NATIONS keys
-            var keys = Object.keys(window.LoreReader.NATIONS);
-            for (var i = 0; i < keys.length; i++) {
-                if (loreIndexName.toLowerCase().indexOf(keys[i].toLowerCase()) !== -1 ||
-                    keys[i].toLowerCase().indexOf(loreIndexName.toLowerCase()) !== -1) {
-                    window.LoreReader.open(keys[i]);
-                    return;
+                resolved = loreIndexName;
+            } else {
+                var keys = Object.keys(window.LoreReader.NATIONS);
+                for (var i = 0; i < keys.length; i++) {
+                    if (loreIndexName.toLowerCase().indexOf(keys[i].toLowerCase()) !== -1 ||
+                        keys[i].toLowerCase().indexOf(loreIndexName.toLowerCase()) !== -1) {
+                        resolved = keys[i];
+                        break;
+                    }
                 }
             }
+        }
+        if (!resolved) resolved = loreIndexName;
+
+        // Si la nation a une page dédiée (slug connu), on navigue. Sinon fallback modal.
+        if (window.NavConfig && typeof NavConfig.slugifyNation === 'function') {
+            var slug = NavConfig.slugifyNation(resolved);
+            if (NavConfig.findNationBySlug(slug)) {
+                window.location.hash = 'nation/' + slug;
+                return;
+            }
+        }
+        if (window.LoreReader && window.LoreReader.open) {
+            window.LoreReader.open(resolved);
         }
     }
 

--- a/js/map.js
+++ b/js/map.js
@@ -2721,7 +2721,18 @@ function initMap() {
         if (!btn) return;
         const hasLore = window.LoreReader && window.LoreReader.NATIONS && window.LoreReader.NATIONS[name];
         btn.style.display = hasLore ? 'block' : 'none';
-        if (hasLore) btn.onclick = () => window.LoreReader.open(name, 'histoires');
+        if (!hasLore) return;
+        btn.onclick = () => {
+            // Si la nation a une page dédiée, on y navigue ; sinon fallback modal.
+            if (window.NavConfig && typeof window.NavConfig.slugifyNation === 'function') {
+                const slug = window.NavConfig.slugifyNation(name);
+                if (window.NavConfig.findNationBySlug(slug)) {
+                    window.location.hash = 'nation/' + slug;
+                    return;
+                }
+            }
+            window.LoreReader.open(name, 'histoires');
+        };
     }
 
     function showFallbackCSV(infoEl, subtitleEl, item) {

--- a/js/nav-config.js
+++ b/js/nav-config.js
@@ -29,7 +29,59 @@ const NavConfig = {
 
     /** Routes internes accessibles via deep-link (pas dans le top nav).
         Quand on navigue vers ces routes, le top-nav highlight 'lore'. */
-    loreSubroutes: ['vision', 'monde', 'mecaniques', 'systemes', 'histoires'],
+    loreSubroutes: ['vision', 'monde', 'mecaniques', 'systemes', 'histoires', 'nation'],
+
+    /** Continents et nations — source unique pour :
+        - la landing lore-histoires (cartes par continent)
+        - la quick-nav latérale sur les routes histoires/nation
+        - la résolution slug → nom de nation pour la page nation.html
+        Ne liste que les nations qui ont au moins un fichier dans Histoires/. */
+    nationContinents: [
+        { key: 'alkaran',  label: 'Alkaran',  intro: '3 nations',    nations: ['Altram', 'Iskara', 'Torkam'] },
+        { key: 'azoria',   label: 'Azoria',   intro: '2 nations',    nations: ['Caeloria', "No Man's Land Azoria"] },
+        { key: 'baelor',   label: 'Baelor',   intro: '1 nation',     nations: ['Baelor'] },
+        { key: 'celethor', label: 'Celethor', intro: '4 nations',    nations: ['Astravia', 'Elarian', 'Ryldor', "No Man's Land Celethor"] },
+        { key: 'cendara',  label: 'Cendara',  intro: '1 nation',     nations: ['Cendara'] },
+        { key: 'cestra',   label: 'Cestra',   intro: '1 territoire', nations: ['Cestra'] },
+        { key: 'endora',   label: 'Endora',   intro: '2 nations',    nations: ['Avalor', 'Haldria'] },
+        { key: 'evertia',  label: 'Evertia',  intro: '2 nations',    nations: ['Evertia', 'Thalmaris'] },
+        { key: 'galenor',  label: 'Galenor',  intro: '7 nations',    nations: ['Kharazir', 'Lumasar', 'Seraphia', 'Solena', 'Trinoria', 'Valoria', 'Ventera'] },
+        { key: 'ilthara',  label: 'Ilthara',  intro: '8 nations',    nations: ['Ackerna', 'Drakora', 'Gryndor', 'Lythar', 'Pyrtara', 'Sylthara', 'Vytharia', 'Warenthor'] },
+        { key: 'nysaria',  label: 'Nysaria',  intro: '1 nation',     nations: ['Nysaria'] },
+        { key: 'onara',    label: 'Onara',    intro: '3 nations',    nations: ['Mosrack', 'Myrtam', 'Tyndara'] },
+        { key: 'ulinor',   label: 'Ulinor',   intro: '2 nations',    nations: ['Skaldoria', 'Ulinor'] },
+    ],
+
+    /** Slug URL-safe à partir d'un nom de nation. Inverse via findNationBySlug. */
+    slugifyNation(name) {
+        return String(name).toLowerCase()
+            .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '');
+    },
+
+    /** Retrouve { nation, continent, continentKey } depuis un slug, ou null. */
+    findNationBySlug(slug) {
+        if (!slug) return null;
+        const conts = this.nationContinents || [];
+        for (const cont of conts) {
+            for (const nation of cont.nations) {
+                if (this.slugifyNation(nation) === slug) {
+                    return { nation, continent: cont.label, continentKey: cont.key };
+                }
+            }
+        }
+        return null;
+    },
+
+    /** Continent qui contient une nation donnée (par nom), ou null. */
+    findContinentForNation(name) {
+        const conts = this.nationContinents || [];
+        for (const cont of conts) {
+            if (cont.nations.includes(name)) return cont;
+        }
+        return null;
+    },
 
     /** Les 8 catégories de la landing Lore. Source unique consommée par :
         - pages/lore.html (les 8 cartes thématiques)

--- a/js/router.js
+++ b/js/router.js
@@ -201,7 +201,51 @@ const Router = {
     },
 };
 
+// ── Mobile sidebar drawer ────────────────────────────────────────────────
+// Sur mobile, le sidebar est masqué par défaut. Un bouton hamburger l'ouvre,
+// un backdrop semi-transparent le ferme. Toute navigation referme aussi.
+const SidebarDrawer = {
+    init() {
+        const toggle   = document.getElementById('sidebar-toggle');
+        const close    = document.getElementById('sidebar-close');
+        const backdrop = document.getElementById('sidebar-backdrop');
+        if (!toggle) return;
+
+        const open = () => {
+            document.body.classList.add('sidebar-open');
+            toggle.setAttribute('aria-expanded', 'true');
+        };
+        const dismiss = () => {
+            document.body.classList.remove('sidebar-open');
+            toggle.setAttribute('aria-expanded', 'false');
+        };
+
+        toggle.addEventListener('click', open);
+        if (close)    close.addEventListener('click', dismiss);
+        if (backdrop) backdrop.addEventListener('click', dismiss);
+
+        // Fermer quand on clique un lien à l'intérieur du sidebar (sauf header/cards
+        // qui ne mènent pas ailleurs).
+        const sidebar = document.getElementById('site-sidebar');
+        if (sidebar) {
+            sidebar.addEventListener('click', e => {
+                const a = e.target.closest('a[href^="#"]');
+                if (a) dismiss();
+            });
+        }
+
+        // Fermer aussi à chaque hashchange (navigation top-nav, deep links, etc.)
+        window.addEventListener('hashchange', dismiss);
+
+        // Escape ferme le drawer
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Escape' && document.body.classList.contains('sidebar-open')) dismiss();
+        });
+    },
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     if (window.NavDropdowns) NavDropdowns.init();
+    SidebarDrawer.init();
     Router.init();
 });

--- a/js/sidebar-lore-nav.js
+++ b/js/sidebar-lore-nav.js
@@ -55,6 +55,51 @@
             return { route: parts[0], subkey: parts.slice(1).join('/') || null };
         },
 
+        /** Rendu spécifique aux routes nation/histoires : continents groupant les nations. */
+        _renderNationNav(route, subkey) {
+            if (!Array.isArray(NavConfig.nationContinents)) return '';
+
+            // Continent actif : déduit de la nation courante si on est sur #nation/<slug>,
+            // ou null si on est sur la landing #histoires/histoires.
+            let activeContinentKey = null;
+            let activeNation = null;
+            if (route === 'nation' && subkey) {
+                const meta = NavConfig.findNationBySlug(subkey);
+                if (meta) {
+                    activeContinentKey = meta.continentKey;
+                    activeNation = meta.nation;
+                }
+            }
+
+            let html = '<div class="sidebar-lore-nav-title">Nations et régions</div>';
+            html += '<ul class="sidebar-lore-nav-list">';
+            for (const cont of NavConfig.nationContinents) {
+                const isActive = activeContinentKey === cont.key;
+                const firstSlug = cont.nations[0]
+                    ? NavConfig.slugifyNation(cont.nations[0])
+                    : null;
+                const headHref = firstSlug ? '#nation/' + firstSlug : '#histoires/histoires';
+                html += '<li class="sidebar-lore-nav-item' + (isActive ? ' active' : '') + '">';
+                html += '  <a class="sidebar-lore-nav-head" href="' + headHref + '">';
+                html += '    <span class="sidebar-lore-nav-label">' + this._escape(cont.label) + '</span>';
+                html += '  </a>';
+                if (isActive) {
+                    html += '  <ul class="sidebar-lore-nav-sublinks">';
+                    for (const nation of cont.nations) {
+                        const slug = NavConfig.slugifyNation(nation);
+                        const linkActive = nation === activeNation;
+                        html += '    <li><a href="#nation/' + slug + '"' +
+                                (linkActive ? ' class="active"' : '') + '>' +
+                                this._escape(nation) + '</a></li>';
+                    }
+                    html += '  </ul>';
+                }
+                html += '</li>';
+            }
+            html += '</ul>';
+            return html;
+        },
+
         render() {
             const { route, subkey } = this._currentRouteAndSubkey();
             if (!this._shouldShow(route)) {
@@ -63,6 +108,16 @@
                 return;
             }
             this._container.hidden = false;
+
+            // Routes nation/* et histoires/histoires (la landing Nations) : on
+            // affiche la quick-nav par continent. Sur histoires/chroniques, on
+            // retombe sur la quick-nav lore classique.
+            const isNationRoute = route === 'nation';
+            const isNationLanding = route === 'histoires' && subkey === 'histoires';
+            if (isNationRoute || isNationLanding) {
+                this._container.innerHTML = this._renderNationNav(route, subkey);
+                return;
+            }
 
             const activeCat = NavConfig.findLoreCategory(route, subkey);
             const activeHash = '#' + route + (subkey ? '/' + subkey : '');

--- a/pages/lore-histoires.html
+++ b/pages/lore-histoires.html
@@ -1,4 +1,4 @@
-<!-- ===== Histoires par Nation ===== -->
+<!-- ===== Histoires par Nation — landing groupée par continent ===== -->
 <div class="section-header" id="histoires">
     <h2>Histoires par Nation</h2>
     <span class="section-count">13 continents · 37 nations</span>
@@ -8,146 +8,49 @@
     <div class="codex-label">Naviguer dans les histoires</div>
     <p style="margin-bottom:0;">
         Chaque nation d'Hybélior possède ses propres chroniques, légendes et récits fondateurs.
-        Sélectionnez un continent pour explorer les histoires de ses nations.
+        Sélectionnez une nation pour ouvrir sa page dédiée.
     </p>
 </div>
 
-<!-- Vue grille continents -->
-<div class="hist-continent-grid" id="hist-continent-grid">
-
-    <div class="hist-continent-card" data-continent="Alkaran">
-        <div class="hist-continent-name">Alkaran</div>
-        <div class="hist-continent-count">3 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Azoria">
-        <div class="hist-continent-name">Azoria</div>
-        <div class="hist-continent-count">2 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Baelor">
-        <div class="hist-continent-name">Baelor</div>
-        <div class="hist-continent-count">1 nation</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Celethor">
-        <div class="hist-continent-name">Celethor</div>
-        <div class="hist-continent-count">4 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Cendara">
-        <div class="hist-continent-name">Cendara</div>
-        <div class="hist-continent-count">1 nation</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Cestra">
-        <div class="hist-continent-name">Cestra</div>
-        <div class="hist-continent-count">1 territoire</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Endora">
-        <div class="hist-continent-name">Endora</div>
-        <div class="hist-continent-count">2 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Evertia">
-        <div class="hist-continent-name">Evertia</div>
-        <div class="hist-continent-count">2 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Galenor">
-        <div class="hist-continent-name">Galenor</div>
-        <div class="hist-continent-count">7 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Ilthara">
-        <div class="hist-continent-name">Ilthara</div>
-        <div class="hist-continent-count">8 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Nysaria">
-        <div class="hist-continent-name">Nysaria</div>
-        <div class="hist-continent-count">1 nation</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Onara">
-        <div class="hist-continent-name">Onara</div>
-        <div class="hist-continent-count">3 nations</div>
-    </div>
-
-    <div class="hist-continent-card" data-continent="Ulinor">
-        <div class="hist-continent-name">Ulinor</div>
-        <div class="hist-continent-count">2 nations</div>
-    </div>
-
-</div>
-
-<!-- Vue nations (cachée par défaut) -->
-<div class="hist-nations-view" id="hist-nations-view" style="display:none;">
-    <button class="hist-back-btn" id="hist-back-btn">← Continents</button>
-    <div class="hist-continent-title" id="hist-continent-title"></div>
-    <div class="hist-nation-list" id="hist-nation-list"></div>
-</div>
+<div class="lore-landing nation-landing" id="nation-landing-container"></div>
 
 <script>
-(function() {
-    // Mapping continent → nations (canon D-LORE-NATIONS-CHEVAL post-2026).
-    // Reflète les fichiers présents dans Docs/Lore/Histoires/<continent>/.
-    // Nations sans fichier Histoires/ (Ferrath, Sanvara, Sylvara, Lunasar, Mirathi,
-    // Arkhen, Pyrevane, Noravia, Azoral, Kethvar, Solmaris, Elarath, Dhalvoria) ne
-    // sont pas listées ici — elles apparaissent uniquement dans lore-geo.html / lore.html.
-    var data = {
-        'Alkaran':  ['Altram', 'Iskara', 'Torkam'],
-        'Azoria':   ['Caeloria', "No Man's Land Azoria"],
-        'Baelor':   ['Baelor'],
-        'Celethor': ['Astravia', 'Elarian', 'Ryldor', "No Man's Land Celethor"],
-        'Cendara':  ['Cendara'],
-        'Cestra':   ['Cestra'],
-        'Endora':   ['Avalor', 'Haldria'],
-        'Evertia':  ['Evertia', 'Thalmaris'],
-        'Galenor':  ['Kharazir', 'Lumasar', 'Seraphia', 'Solena', 'Trinoria', 'Valoria', 'Ventera'],
-        'Ilthara':  ['Ackerna', 'Drakora', 'Gryndor', 'Lythar', 'Pyrtara', 'Sylthara', 'Vytharia', 'Warenthor'],
-        'Nysaria':  ['Nysaria'],
-        'Onara':    ['Mosrack', 'Myrtam', 'Tyndara'],
-        'Ulinor':   ['Skaldoria', 'Ulinor']
-    };
+(function () {
+    var container = document.getElementById('nation-landing-container');
+    if (!container || !window.NavConfig || !Array.isArray(NavConfig.nationContinents)) return;
 
-    var grid     = document.getElementById('hist-continent-grid');
-    var view     = document.getElementById('hist-nations-view');
-    var backBtn  = document.getElementById('hist-back-btn');
-    var titleEl  = document.getElementById('hist-continent-title');
-    var listEl   = document.getElementById('hist-nation-list');
+    function escapeHtml(s) {
+        var d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
 
-    // Clic sur une card continent
-    grid.addEventListener('click', function(e) {
-        var card = e.target.closest('.hist-continent-card');
-        if (!card) return;
-        var continent = card.dataset.continent;
-        var nations = data[continent] || [];
-
-        titleEl.textContent = continent;
-        listEl.innerHTML = '';
-        nations.forEach(function(nation) {
-            var btn = document.createElement('button');
-            btn.className = 'hist-nation-btn';
-            btn.dataset.nation = nation;
-            btn.textContent = nation;
-            btn.addEventListener('click', function() {
-                if (window.LoreReader && window.LoreReader.open) {
-                    window.LoreReader.open(nation, 'histoires');
-                }
-            });
-            listEl.appendChild(btn);
+    var html = '';
+    NavConfig.nationContinents.forEach(function (cont) {
+        var firstSlug = cont.nations[0] ? NavConfig.slugifyNation(cont.nations[0]) : '';
+        var firstHref = firstSlug ? '#nation/' + firstSlug : '#histoires/histoires';
+        html += '<div class="lore-card" data-href="' + escapeHtml(firstHref) + '">';
+        html += '  <h2 class="lore-card-title"><a href="' + escapeHtml(firstHref) + '">' +
+                escapeHtml(cont.label) + '</a></h2>';
+        html += '  <p class="lore-card-intro">' + escapeHtml(cont.intro) + '</p>';
+        html += '  <ul class="lore-card-links">';
+        cont.nations.forEach(function (nation) {
+            var slug = NavConfig.slugifyNation(nation);
+            html += '<li><a href="#nation/' + escapeHtml(slug) + '">' +
+                    escapeHtml(nation) + '</a></li>';
         });
-
-        grid.style.display = 'none';
-        view.style.display = 'block';
+        html += '  </ul>';
+        html += '</div>';
     });
+    container.innerHTML = html;
 
-    // Bouton retour
-    backBtn.addEventListener('click', function() {
-        view.style.display = 'none';
-        grid.style.display = 'grid';
+    container.querySelectorAll('.lore-card[data-href]').forEach(function (card) {
+        card.style.cursor = 'pointer';
+        card.addEventListener('click', function (e) {
+            if (e.target.closest('a')) return;
+            var href = card.getAttribute('data-href');
+            if (href) window.location.hash = href.replace(/^#/, '');
+        });
     });
 })();
 </script>

--- a/pages/nation.html
+++ b/pages/nation.html
@@ -1,0 +1,152 @@
+<!-- ===== Page Nation : description + histoire d'une nation ===== -->
+<div class="nation-page">
+    <div class="nation-page-crumbs">
+        <a href="#histoires/histoires" class="nation-page-back">← Toutes les nations</a>
+        <span class="nation-page-crumbs-sep">·</span>
+        <span class="nation-page-continent" id="nation-page-continent"></span>
+    </div>
+
+    <h1 class="nation-page-title" id="nation-page-title">Nation</h1>
+
+    <div class="nation-page-tabs" id="nation-page-tabs">
+        <button class="nation-page-tab active" data-tab="pays">Description</button>
+        <button class="nation-page-tab" data-tab="histoires">Histoire</button>
+    </div>
+
+    <div class="nation-page-body" id="nation-page-body">
+        <div class="nation-page-loading">Sélectionnez une nation depuis la page des histoires.</div>
+    </div>
+</div>
+
+<script>
+(function () {
+    'use strict';
+
+    var titleEl     = document.getElementById('nation-page-title');
+    var continentEl = document.getElementById('nation-page-continent');
+    var tabsEl      = document.getElementById('nation-page-tabs');
+    var bodyEl      = document.getElementById('nation-page-body');
+
+    var _cache = {};
+    var _currentNation = null;
+    var _currentTab = 'pays';
+
+    function currentSubkey() {
+        var raw = window.location.hash.slice(1);
+        var parts = raw.split('/');
+        if (parts[0] !== 'nation') return null;
+        return parts.slice(1).join('/') || null;
+    }
+
+    function getNationInfo(slug) {
+        if (!window.NavConfig || typeof NavConfig.findNationBySlug !== 'function') return null;
+        var meta = NavConfig.findNationBySlug(slug);
+        if (!meta) return null;
+        var paths = window.LoreReader && LoreReader.NATIONS && LoreReader.NATIONS[meta.nation];
+        if (!paths) return null;
+        return {
+            nation: meta.nation,
+            continent: meta.continent,
+            pays: paths.pays,
+            histoires: paths.histoires,
+        };
+    }
+
+    function renderMarkdown(text) {
+        var clean = text.replace(/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g,
+            function (_, file, display) { return display || file; });
+        if (typeof marked !== 'undefined') {
+            return marked.parse(clean, { breaks: true });
+        }
+        return '<pre>' + clean.replace(/[<>&]/g, function (c) {
+            return ({'<':'&lt;','>':'&gt;','&':'&amp;'})[c];
+        }) + '</pre>';
+    }
+
+    function loadTab(tab) {
+        var info = _currentNation;
+        if (!info) return;
+        _currentTab = tab;
+
+        var url = tab === 'pays' ? info.pays : info.histoires;
+        if (!url) {
+            bodyEl.innerHTML = '<div class="nation-page-error">Aucun contenu disponible pour cet onglet.</div>';
+            return;
+        }
+
+        function paint(text) {
+            bodyEl.innerHTML = '<div class="lore-md-content">' + renderMarkdown(text) + '</div>';
+            window.scrollTo({ top: 0, behavior: 'instant' });
+            // Rebuild sidebar TOC from rendered markdown
+            var sidebar = document.getElementById('site-sidebar');
+            var content = document.querySelector('.page-content');
+            if (sidebar && content && window.SidebarTOC) {
+                SidebarTOC.build(sidebar, content);
+            }
+        }
+
+        if (_cache[url]) { paint(_cache[url]); return; }
+
+        bodyEl.innerHTML = '<div class="nation-page-loading">Chargement…</div>';
+        fetch('/lore/' + url).then(function (r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status);
+            return r.text();
+        }).then(function (text) {
+            _cache[url] = text;
+            paint(text);
+        }).catch(function (err) {
+            bodyEl.innerHTML = '<div class="nation-page-error">Impossible de charger le fichier.<br><small>' +
+                (err && err.message ? err.message : err) + '</small></div>';
+        });
+    }
+
+    function activateTab(tab) {
+        tabsEl.querySelectorAll('.nation-page-tab').forEach(function (b) {
+            b.classList.toggle('active', b.dataset.tab === tab);
+        });
+        loadTab(tab);
+    }
+
+    function renderForCurrentSlug() {
+        var slug = currentSubkey();
+        if (!slug) return;
+
+        var info = getNationInfo(slug);
+        if (!info) {
+            titleEl.textContent = 'Nation introuvable';
+            continentEl.textContent = '';
+            bodyEl.innerHTML = '<div class="nation-page-error">Aucune nation ne correspond à ce slug.</div>';
+            return;
+        }
+
+        _currentNation = info;
+        titleEl.textContent = info.nation;
+        continentEl.textContent = info.continent;
+
+        // Cache l'onglet Histoire si pas de fichier
+        var histTab = tabsEl.querySelector('[data-tab="histoires"]');
+        if (histTab) histTab.style.display = info.histoires ? '' : 'none';
+
+        var startTab = info.pays ? 'pays' : 'histoires';
+        activateTab(startTab);
+    }
+
+    // Délégation des clics sur les onglets
+    tabsEl.addEventListener('click', function (e) {
+        var btn = e.target.closest('.nation-page-tab');
+        if (!btn) return;
+        activateTab(btn.dataset.tab);
+    });
+
+    // Quand on navigue entre nations, le router ne recharge pas nation.html ;
+    // on écoute hashchange pour re-rendre. On nettoie d'abord l'éventuel
+    // listener d'une précédente instance.
+    if (window._nationPageHandler) {
+        window.removeEventListener('hashchange', window._nationPageHandler);
+    }
+    window._nationPageHandler = renderForCurrentSlug;
+    window.addEventListener('hashchange', renderForCurrentSlug);
+
+    renderForCurrentSlug();
+})();
+</script>


### PR DESCRIPTION
## Summary

- Chaque nation a maintenant sa propre route `#nation/<slug>` et sa page dédiée plutôt qu'un modal en superposition.
- La landing **Histoires par Nation** est reorganisée comme la landing **Lore** : une carte par continent (13) avec la liste de ses nations en sous-liens cliquables.
- Le sidebar gauche affiche désormais une quick-nav "Nations et régions" avec les 13 continents ; le continent actif déplie ses nations (mise en évidence de la nation courante).
- Les points d'entrée existants (recherche globale, bouton "Lire le lore" du panneau Carte) routent vers la page dédiée si un slug est connu, avec fallback modal sinon.

## Changements clés

- `js/nav-config.js` — ajout de `loreSubroutes: 'nation'`, du dataset `nationContinents`, et des helpers `slugifyNation` / `findNationBySlug` / `findContinentForNation`.
- `pages/nation.html` (nouveau) — page-coquille qui lit le slug depuis le hash, résout via `NavConfig.findNationBySlug` + `LoreReader.NATIONS`, et rend Description / Histoire avec onglets inline. Écoute `hashchange` pour gérer la navigation inter-nations sans recharger la page.
- `pages/lore-histoires.html` — réécrite : grille de cartes `.lore-card` par continent avec sous-liens vers `#nation/<slug>`. Plus de vue "expanded continent" sur place.
- `js/sidebar-lore-nav.js` — branche de rendu spécifique pour `#nation/*` et `#histoires/histoires` qui affiche la liste des continents avec sous-liens nations sous le continent actif.
- `js/lore-search.js` & `js/lore-reader.js` & `js/map.js` — anciens points d'ouverture du modal résolvent désormais vers `#nation/<slug>` si la nation est connue ; modal conservé en fallback.
- `css/style.css` — styles `.nation-page-*` (titre, fil d'Ariane, onglets, body).

## Test plan

- [ ] `#lore` → carte "Chroniques et lecture du monde" → lien **Nations** → la landing montre 13 cartes-continents avec les nations en sous-liens
- [ ] Cliquer un lien de nation (ex. **Altram**) ouvre `#nation/altram`, page pleine largeur avec onglets Description / Histoire
- [ ] Cliquer un autre lien nation depuis le sidebar (ex. **Torkam**) re-rend la page sans flash (hashchange)
- [ ] Une nation sans fichier `Histoires/` n'affiche pas l'onglet Histoire
- [ ] Recherche globale "Altram" → navigue vers `#nation/altram`, pas de modal
- [ ] Sur la carte, sélectionner une nation puis cliquer **Lire le lore** → ouvre la page dédiée
- [ ] Slug inconnu (`#nation/foobar`) affiche le message "Nation introuvable"
- [ ] Sidebar : sur `#nation/altram`, le continent Alkaran est déplié et Altram en surbrillance ; les autres continents sont collapse
- [ ] L'onglet **Chroniques** de la route histoires conserve son ancien comportement (sidebar lore classique)

---
_Generated by [Claude Code](https://claude.ai/code/session_017VU1nozRH6vuqMWQFURZn6)_