### PR TITLE
fix(mobile-drawer): masquer × tant que drawer fermé + buster cache CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3728,14 +3728,18 @@ select:focus-visible,
 
     /* Bouton hamburger flottant — visible quand le sidebar est utile */
     .sidebar-toggle {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         gap: 7px;
         position: fixed;
         top: calc(var(--nav-height) + 8px);
         left: 10px;
+        right: auto;
+        width: auto;
+        max-width: max-content;
         z-index: 25;
         padding: 7px 12px 7px 10px;
+        margin: 0;
         background: rgba(232, 222, 200, 0.95);
         border: 1px solid rgba(120, 78, 18, 0.30);
         border-radius: 20px;
@@ -3759,9 +3763,9 @@ select:focus-visible,
     }
     body.sidebar-open .sidebar-toggle { display: none; }
 
-    /* Bouton fermer dans la sidebar */
+    /* Bouton fermer dans la sidebar — visible uniquement quand le drawer est ouvert */
     .sidebar-close {
-        display: block;
+        display: none;
         position: absolute;
         top: 6px;
         right: 6px;
@@ -3775,6 +3779,7 @@ select:focus-visible,
         color: var(--gold, #7a4c0a);
         cursor: pointer;
     }
+    body.sidebar-open .sidebar-close { display: block; }
 
     /* Subtab-nav reste vertical dans le drawer */
     .site-sidebar .subtab-nav {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16.png">
     <link rel="icon" type="image/svg+xml" href="/icons/favicon.svg">
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/css/style.css?v=2026-05-18-mobile-drawer">
     <link rel="manifest" href="/manifest.webmanifest">
     <meta name="description" content="Hybélior — Explorez un monde dark fantasy avec 13 continents, 37 nations, une cosmologie profonde et un gameplay innovant.">
     <meta property="og:title" content="Hybélior — World of Dark Fantasy">

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Hybélior PWA service worker.
 // Bumping VERSION invalidates all caches on next visit, forcing a refresh.
-const VERSION = '2026-05-13-3';
+const VERSION = '2026-05-18-mobile-drawer';
 const PRECACHE = `hybelior-precache-${VERSION}`;
 const RUNTIME  = `hybelior-runtime-${VERSION}`;
 


### PR DESCRIPTION
## Pourquoi

Sur la PR précédente, le drawer mobile s'affichait incorrectement (× de fermeture visible même drawer fermé, bouton Menu pris dans une bizarrerie de largeur). Deux causes :

1. **Cache CSS obsolète** chez les clients qui avaient l'ancien SW : le `staleWhileRevalidate` sert l'ancien CSS au premier paint et le drawer (qui n'existait pas dans l'ancien CSS) tombe en visuel cassé.
2. **`.sidebar-close` toujours visible** : sur certains contextes iOS, le `transform: translateX(-100%)` sur la sidebar `position: fixed` n'évacue pas visuellement l'enfant absolu de la fenêtre.

## Changements

- `css/style.css` : `.sidebar-close` masqué par défaut, affiché uniquement quand `body.sidebar-open`. Bouton `.sidebar-toggle` borné à `width: auto / max-content` + `margin: 0` pour qu'aucun reset ne le force pleine largeur.
- `sw.js` : VERSION bumpée pour invalider tous les caches au prochain visit.
- `index.html` : ajout d'un query-param `?v=…` sur le `<link>` CSS pour bypass cache navigateur même quand le SW sert l'ancien.

## Test plan

- [ ] Sur mobile (≤ 768px), au chargement initial : seul le bouton « Menu » est visible, le « × » NE l'est PAS
- [ ] Taper « Menu » → la sidebar glisse depuis la gauche, backdrop apparaît, « × » devient visible en haut à droite du drawer
- [ ] Taper sur backdrop / « × » / Escape → drawer se ferme
- [ ] Naviguer vers une page (clic dans le drawer) → drawer se ferme automatiquement
- [ ] Sur desktop (> 768px) : aucun changement (sidebar sticky, pas de toggle visible)

---
_Generated by [Claude Code](https://claude.ai/code/session_017VU1nozRH6vuqMWQFURZn6)_