### PR TITLE
feat(sidebar): nicher continents/nations sous Nations + religions sous Religions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4419,6 +4419,72 @@ select:focus-visible,
     background: rgba(120, 78, 18, 0.08);
 }
 
+/* Sous-arbres imbriqués (Nations → continents → nations, Religions → religions) */
+.sidebar-lore-nav-subtree {
+    list-style: none;
+    margin: 2px 0 4px 12px;
+    padding: 0;
+    border-left: 1px solid rgba(120, 78, 18, 0.14);
+}
+.sidebar-lore-nav-subitem { margin: 0; padding: 0; }
+.sidebar-lore-nav-subhead {
+    display: block;
+    padding: 2px 10px;
+    margin-left: -1px;
+    font-size: 11px;
+    color: var(--text-muted, #6a5438);
+    text-decoration: none;
+    border-left: 1px solid transparent;
+    transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.sidebar-lore-nav-subhead:hover {
+    color: var(--gold, #7a4c0a);
+    background: rgba(120, 78, 18, 0.05);
+}
+.sidebar-lore-nav-subhead.active {
+    color: var(--gold, #7a4c0a);
+    font-weight: 600;
+    border-left-color: var(--gold, #7a4c0a);
+    background: rgba(120, 78, 18, 0.08);
+}
+.sidebar-lore-nav-subhead.special {
+    font-style: italic;
+    color: var(--text-soft, #3c2c18);
+}
+.sidebar-lore-nav-subhead.mineure {
+    opacity: 0.78;
+    font-size: 10.5px;
+}
+
+/* Feuilles : 3e niveau (nations d'un continent) */
+.sidebar-lore-nav-subleaves {
+    list-style: none;
+    margin: 1px 0 4px 12px;
+    padding: 0;
+    border-left: 1px solid rgba(120, 78, 18, 0.12);
+}
+.sidebar-lore-nav-subleaves li { margin: 0; padding: 0; }
+.sidebar-lore-nav-subleaves a {
+    display: block;
+    padding: 2px 10px;
+    margin-left: -1px;
+    font-size: 10.5px;
+    color: var(--text-muted, #6a5438);
+    text-decoration: none;
+    border-left: 1px solid transparent;
+    transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.sidebar-lore-nav-subleaves a:hover {
+    color: var(--gold, #7a4c0a);
+    background: rgba(120, 78, 18, 0.05);
+}
+.sidebar-lore-nav-subleaves a.active {
+    color: var(--gold, #7a4c0a);
+    font-weight: 600;
+    border-left-color: var(--gold, #7a4c0a);
+    background: rgba(120, 78, 18, 0.08);
+}
+
 @media (max-width: 768px) {
     /* Sur mobile, le sidebar devient un drawer coulissant (cf. règles plus haut).
        Le quick-nav y reste visible — c'est même son intérêt principal en mobile

--- a/js/nav-config.js
+++ b/js/nav-config.js
@@ -83,6 +83,38 @@ const NavConfig = {
         return null;
     },
 
+    /** Religions — source unique pour le sidebar et la page de hub. */
+    religions: [
+        { key: 'systeme',  label: 'Système religieux',   md: 'Lore/Religions/00 - Système Religieux.md',     special: true },
+        { key: 'histoire', label: 'Histoire & schismes', md: 'Lore/Religions/_Histoire des Religions.md',    special: true },
+        { key: 'foedus',   label: 'Foedus Animae',       md: 'Lore/Religions/Foedus Animae.md' },
+        { key: 'ignis',    label: 'Ignis Aeternum',      md: 'Lore/Religions/Ignis Aeternum.md' },
+        { key: 'lex',      label: 'Lex Petra',           md: 'Lore/Religions/Lex Petra.md' },
+        { key: 'noctari',  label: 'Noctari',             md: 'Lore/Religions/Noctari.md' },
+        { key: 'ordo',     label: 'Ordo Caelum',         md: 'Lore/Religions/Ordo Caelum.md' },
+        { key: 'rota',     label: 'Rota Mundi',          md: 'Lore/Religions/Rota Mundi.md' },
+        { key: 'somnium',  label: 'Somnium Vigil',       md: 'Lore/Religions/Somnium Vigil.md' },
+        { key: 'vael',     label: 'Vael Kurash',         md: 'Lore/Religions/Vael Kurash.md' },
+        { key: 'via',      label: 'Via Ventus',          md: 'Lore/Religions/Via Ventus.md' },
+        { key: 'aqua',     label: 'Aqua Nigra',          md: 'Lore/Religions/_Mineures/Aqua Nigra.md',     mineure: true },
+        { key: 'cantus',   label: 'Cantus Mundi',        md: 'Lore/Religions/_Mineures/Cantus Mundi.md',   mineure: true },
+        { key: 'catena',   label: 'Catena Fracta',       md: 'Lore/Religions/_Mineures/Catena Fracta.md',  mineure: true },
+        { key: 'filii',    label: 'Filii Fornacis',      md: 'Lore/Religions/_Mineures/Filii Fornacis.md', mineure: true },
+        { key: 'taciti',   label: 'Taciti',              md: 'Lore/Religions/_Mineures/Taciti.md',         mineure: true },
+    ],
+
+    /** URL hash pour ouvrir une religion en page-md autonome. */
+    religionMdHref(md) {
+        return '#md/' + encodeURIComponent(md);
+    },
+
+    /** Retrouve la religion correspondant à un chemin md (subkey du route 'md'). */
+    findReligionByMdPath(path) {
+        if (!path) return null;
+        const norm = decodeURIComponent(path);
+        return (this.religions || []).find(r => r.md === norm) || null;
+    },
+
     /** Les 8 catégories de la landing Lore. Source unique consommée par :
         - pages/lore.html (les 8 cartes thématiques)
         - js/sidebar-lore-nav.js (quick-nav du sidebar, switch rapide entre cats)
@@ -198,6 +230,20 @@ const NavConfig = {
         retourne la catégorie Lore correspondante, ou null. */
     findLoreCategory(route, subkey) {
         if (!route) return null;
+
+        // Routes spéciales sans entrée directe dans loreCategories :
+        //   - #nation/<slug>             → catégorie Chroniques (sous le lien "Nations")
+        //   - #md/Lore/Religions/*       → catégorie Chroniques (sous le lien "Religions")
+        if (route === 'nation') {
+            return (this.loreCategories || []).find(c => c.key === 'chroniques') || null;
+        }
+        if (route === 'md' && subkey) {
+            const path = decodeURIComponent(subkey);
+            if (path.startsWith('Lore/Religions/')) {
+                return (this.loreCategories || []).find(c => c.key === 'chroniques') || null;
+            }
+        }
+
         const hash = '#' + route + (subkey ? '/' + subkey : '');
         const cats = this.loreCategories || [];
         for (const cat of cats) {

--- a/js/sidebar-lore-nav.js
+++ b/js/sidebar-lore-nav.js
@@ -1,17 +1,21 @@
 /**
  * sidebar-lore-nav.js — Quick-nav Lore en haut du sidebar.
  *
- * Sur les routes Lore (loreSubroutes), affiche un menu compact des 8
- * catégories thématiques (icon + label). Quand on est sur une page,
- * la catégorie active est mise en évidence et ses sous-liens sont
- * dépliés ; les autres restent collapse (juste icon + label).
+ * Sur les routes Lore (loreSubroutes + #md/Lore/...), affiche un menu
+ * compact des 8 catégories thématiques. La catégorie active est
+ * dépliée ; ses sous-liens sont listés ; un sous-lien peut lui-même
+ * porter un sous-arbre (Nations → continents → nations, Religions
+ * → liste des religions).
  *
- * Données : NavConfig.loreCategories
+ * Données : NavConfig.loreCategories + NavConfig.nationContinents + NavConfig.religions
  * Cible : <aside id="site-sidebar"> (au-dessus du TOC).
  */
 
 (function () {
     'use strict';
+
+    const NATIONS_LINK_HREF   = '#histoires/histoires';
+    const RELIGIONS_LINK_HREF = '#monde/religions';
 
     const SidebarLoreNav = {
         _container: null,
@@ -21,7 +25,6 @@
             const sidebar = document.getElementById('site-sidebar');
             if (!sidebar) return;
 
-            // Crée le conteneur juste après lore-search-wrapper, avant le reste.
             this._container = document.createElement('div');
             this._container.id = 'sidebar-lore-nav';
             this._container.className = 'sidebar-lore-nav';
@@ -36,59 +39,128 @@
                 sidebar.insertBefore(this._container, sidebar.firstChild);
             }
 
-            // Rendu initial + hashchange
             this.render();
             window.addEventListener('hashchange', () => this.render());
         },
 
         /** Détermine si la route courante mérite la quick-nav. */
-        _shouldShow(route) {
+        _shouldShow(route, subkey) {
             const subs = (NavConfig.loreSubroutes || []);
-            return route === 'lore' || subs.includes(route);
+            if (route === 'lore' || subs.includes(route)) return true;
+            // Pages Lore servies via #md/Lore/...
+            if (route === 'md' && subkey) {
+                try {
+                    return decodeURIComponent(subkey).startsWith('Lore/');
+                } catch (_) { return false; }
+            }
+            return false;
         },
 
         /** Récupère la route + subkey courants depuis le hash. */
         _currentRouteAndSubkey() {
             const raw = window.location.hash.slice(1);
             if (!raw) return { route: 'accueil', subkey: null };
+            if (raw.startsWith('md/')) {
+                return { route: 'md', subkey: raw.slice(3) };
+            }
             const parts = raw.split('/');
             return { route: parts[0], subkey: parts.slice(1).join('/') || null };
         },
 
-        /** Rendu spécifique aux routes nation/histoires : continents groupant les nations. */
-        _renderNationNav(route, subkey) {
-            if (!Array.isArray(NavConfig.nationContinents)) return '';
-
-            // Continent actif : déduit de la nation courante si on est sur #nation/<slug>,
-            // ou null si on est sur la landing #histoires/histoires.
-            let activeContinentKey = null;
-            let activeNation = null;
-            if (route === 'nation' && subkey) {
-                const meta = NavConfig.findNationBySlug(subkey);
-                if (meta) {
-                    activeContinentKey = meta.continentKey;
-                    activeNation = meta.nation;
-                }
+        render() {
+            const { route, subkey } = this._currentRouteAndSubkey();
+            if (!this._shouldShow(route, subkey)) {
+                this._container.hidden = true;
+                this._container.innerHTML = '';
+                return;
             }
+            this._container.hidden = false;
 
-            let html = '<div class="sidebar-lore-nav-title">Nations et régions</div>';
+            const activeCat = NavConfig.findLoreCategory(route, subkey);
+            const activeHash = '#' + route + (subkey ? '/' + subkey : '');
+
+            // Contextes spéciaux
+            const onNationRoute    = route === 'nation' && !!subkey;
+            const onNationLanding  = route === 'histoires' && subkey === 'histoires';
+            const isOnNations      = onNationRoute || onNationLanding;
+            const activeNationMeta = onNationRoute
+                ? NavConfig.findNationBySlug(subkey)
+                : null;
+
+            const isOnReligionsHub = route === 'monde' && subkey === 'religions';
+            const isOnMdReligion   = route === 'md' && subkey &&
+                                     decodeURIComponent(subkey).startsWith('Lore/Religions/');
+            const isOnReligions    = isOnReligionsHub || isOnMdReligion;
+            const activeReligion   = isOnMdReligion
+                ? NavConfig.findReligionByMdPath(subkey)
+                : null;
+
+            let html = '<div class="sidebar-lore-nav-title">Parcourir le lore</div>';
             html += '<ul class="sidebar-lore-nav-list">';
-            for (const cont of NavConfig.nationContinents) {
-                const isActive = activeContinentKey === cont.key;
-                const firstSlug = cont.nations[0]
-                    ? NavConfig.slugifyNation(cont.nations[0])
-                    : null;
-                const headHref = firstSlug ? '#nation/' + firstSlug : '#histoires/histoires';
+
+            for (const cat of NavConfig.loreCategories) {
+                const isActive  = activeCat && activeCat.key === cat.key;
+                const firstHref = cat.links[0] ? cat.links[0].href : '#lore';
+
                 html += '<li class="sidebar-lore-nav-item' + (isActive ? ' active' : '') + '">';
-                html += '  <a class="sidebar-lore-nav-head" href="' + headHref + '">';
-                html += '    <span class="sidebar-lore-nav-label">' + this._escape(cont.label) + '</span>';
+                html += '  <a class="sidebar-lore-nav-head" href="' + firstHref + '">';
+                html += '    <span class="sidebar-lore-nav-icon" aria-hidden="true">' + cat.icon + '</span>';
+                html += '    <span class="sidebar-lore-nav-label">' + this._escape(cat.label) + '</span>';
                 html += '  </a>';
+
                 if (isActive) {
                     html += '  <ul class="sidebar-lore-nav-sublinks">';
+                    for (const link of cat.links) {
+                        let linkActive = link.href === activeHash;
+                        // Lien Nations actif sur les routes nation/* et la landing
+                        if (link.href === NATIONS_LINK_HREF && isOnNations) linkActive = true;
+                        // Lien Religions actif sur #md/Lore/Religions/* et le hub
+                        if (link.href === RELIGIONS_LINK_HREF && isOnReligions) linkActive = true;
+
+                        html += '<li>';
+                        html += '<a href="' + link.href + '"' +
+                                (linkActive ? ' class="active"' : '') + '>' +
+                                this._escape(link.label) + '</a>';
+
+                        // Sous-arbres
+                        if (link.href === NATIONS_LINK_HREF && isOnNations) {
+                            html += this._renderNationsTree(activeNationMeta);
+                        }
+                        if (link.href === RELIGIONS_LINK_HREF && isOnReligions) {
+                            html += this._renderReligionsTree(activeReligion);
+                        }
+
+                        html += '</li>';
+                    }
+                    html += '  </ul>';
+                }
+                html += '</li>';
+            }
+            html += '</ul>';
+            this._container.innerHTML = html;
+        },
+
+        /** Arbre continents → nations, avec le continent de la nation active déplié. */
+        _renderNationsTree(activeNationMeta) {
+            if (!Array.isArray(NavConfig.nationContinents)) return '';
+            const activeContinentKey = activeNationMeta ? activeNationMeta.continentKey : null;
+            const activeNation       = activeNationMeta ? activeNationMeta.nation : null;
+
+            let html = '<ul class="sidebar-lore-nav-subtree">';
+            for (const cont of NavConfig.nationContinents) {
+                const isActive  = activeContinentKey === cont.key;
+                const firstSlug = cont.nations[0] ? NavConfig.slugifyNation(cont.nations[0]) : null;
+                const headHref  = firstSlug ? '#nation/' + firstSlug : NATIONS_LINK_HREF;
+
+                html += '<li class="sidebar-lore-nav-subitem' + (isActive ? ' active' : '') + '">';
+                html += '  <a class="sidebar-lore-nav-subhead' + (isActive ? ' active' : '') + '" href="' +
+                        headHref + '">' + this._escape(cont.label) + '</a>';
+                if (isActive) {
+                    html += '  <ul class="sidebar-lore-nav-subleaves">';
                     for (const nation of cont.nations) {
-                        const slug = NavConfig.slugifyNation(nation);
+                        const slug       = NavConfig.slugifyNation(nation);
                         const linkActive = nation === activeNation;
-                        html += '    <li><a href="#nation/' + slug + '"' +
+                        html += '<li><a href="#nation/' + slug + '"' +
                                 (linkActive ? ' class="active"' : '') + '>' +
                                 this._escape(nation) + '</a></li>';
                     }
@@ -100,53 +172,24 @@
             return html;
         },
 
-        render() {
-            const { route, subkey } = this._currentRouteAndSubkey();
-            if (!this._shouldShow(route)) {
-                this._container.hidden = true;
-                this._container.innerHTML = '';
-                return;
-            }
-            this._container.hidden = false;
-
-            // Routes nation/* et histoires/histoires (la landing Nations) : on
-            // affiche la quick-nav par continent. Sur histoires/chroniques, on
-            // retombe sur la quick-nav lore classique.
-            const isNationRoute = route === 'nation';
-            const isNationLanding = route === 'histoires' && subkey === 'histoires';
-            if (isNationRoute || isNationLanding) {
-                this._container.innerHTML = this._renderNationNav(route, subkey);
-                return;
-            }
-
-            const activeCat = NavConfig.findLoreCategory(route, subkey);
-            const activeHash = '#' + route + (subkey ? '/' + subkey : '');
-
-            let html = '<div class="sidebar-lore-nav-title">Parcourir le lore</div>';
-            html += '<ul class="sidebar-lore-nav-list">';
-
-            for (const cat of NavConfig.loreCategories) {
-                const isActive = activeCat && activeCat.key === cat.key;
-                const firstHref = cat.links[0] ? cat.links[0].href : '#lore';
-                html += '<li class="sidebar-lore-nav-item' + (isActive ? ' active' : '') + '">';
-                html += '  <a class="sidebar-lore-nav-head" href="' + firstHref + '">';
-                html += '    <span class="sidebar-lore-nav-icon" aria-hidden="true">' + cat.icon + '</span>';
-                html += '    <span class="sidebar-lore-nav-label">' + cat.label + '</span>';
-                html += '  </a>';
-                if (isActive) {
-                    html += '  <ul class="sidebar-lore-nav-sublinks">';
-                    for (const link of cat.links) {
-                        const linkActive = link.href === activeHash;
-                        html += '    <li><a href="' + link.href + '"' +
-                                (linkActive ? ' class="active"' : '') + '>' +
-                                this._escape(link.label) + '</a></li>';
-                    }
-                    html += '  </ul>';
-                }
+        /** Liste plate des religions. Une religion active est mise en évidence. */
+        _renderReligionsTree(activeReligion) {
+            if (!Array.isArray(NavConfig.religions)) return '';
+            let html = '<ul class="sidebar-lore-nav-subtree">';
+            for (const rel of NavConfig.religions) {
+                const linkActive = activeReligion && activeReligion.key === rel.key;
+                const href       = NavConfig.religionMdHref(rel.md);
+                const classes    = 'sidebar-lore-nav-subhead' +
+                                   (rel.mineure ? ' mineure' : '') +
+                                   (rel.special ? ' special' : '') +
+                                   (linkActive ? ' active' : '');
+                html += '<li class="sidebar-lore-nav-subitem">';
+                html += '  <a class="' + classes + '" href="' + href + '">' +
+                        this._escape(rel.label) + '</a>';
                 html += '</li>';
             }
             html += '</ul>';
-            this._container.innerHTML = html;
+            return html;
         },
 
         _escape(s) {

--- a/server.js
+++ b/server.js
@@ -243,7 +243,13 @@ const server = http.createServer(async (req, res) => {
     }
 
     // ── Static files ──────────────────────────────────────────
-    let filePath = path.join(__dirname, pathname === '/' ? 'index.html' : pathname);
+    let decodedPath;
+    try { decodedPath = decodeURIComponent(pathname); }
+    catch { decodedPath = pathname; }
+    if (decodedPath.includes('..') || decodedPath.includes('\0')) {
+        res.writeHead(400); return res.end('Bad request');
+    }
+    let filePath = path.join(__dirname, decodedPath === '/' ? 'index.html' : decodedPath);
     try {
         const stat = fs.statSync(filePath);
         if (stat.isDirectory()) filePath = path.join(filePath, 'index.html');


### PR DESCRIPTION
## Pourquoi

La PR précédente remplaçait tout le panneau "Parcourir le lore" par un panneau "Nations et régions" séparé sur les routes nation/histoires. Demande utilisateur : garder le lore-nav et **nicher** les continents/nations **sous le lien "Nations"**. Idem pour les religions sous "Religions".

## Changements

- **`js/nav-config.js`** :
  - Nouvel array `religions` (16 entrées : 10 majeures + Système + Histoire + 5 mineures) avec leur chemin md.
  - `religionMdHref()` / `findReligionByMdPath()` pour le routage.
  - `findLoreCategory()` gère 2 cas spéciaux : route `nation` → chroniques, route `md` avec path `Lore/Religions/...` → chroniques.

- **`js/sidebar-lore-nav.js`** : refonte du render.
  - Supprime le panneau séparé "Nations et régions".
  - Toujours affiche "Parcourir le lore" + les 8 catégories.
  - Pour le lien "Nations" actif : injecte un sous-arbre continent → nations (continent de la nation active déplié, nation active en surbrillance).
  - Pour le lien "Religions" actif : injecte la liste des religions (religion active en surbrillance, mineures atténuées).
  - `_shouldShow` accepte aussi le route `md` quand le path commence par `Lore/`.

- **`css/style.css`** : styles pour `.sidebar-lore-nav-subtree`, `.sidebar-lore-nav-subitem`, `.sidebar-lore-nav-subhead`, `.sidebar-lore-nav-subleaves` (2e et 3e niveau d'imbrication).

- **`server.js`** (dev local) : décode `pathname` pour servir les fichiers avec espaces (déjà OK sur Vercel).

## Test plan

- [ ] `#nation/altram` → panneau "Parcourir le lore" visible, catégorie "Chroniques" dépliée, lien "Nations" actif, sous-arbre avec **Alkaran** déplié, **Altram** en surbrillance ; les autres continents collapse en sous-titres
- [ ] `#histoires/histoires` (landing) → lien Nations actif, sous-arbre visible mais aucun continent déplié
- [ ] Cliquer un continent du sous-arbre → navigue vers la 1re nation du continent
- [ ] `#monde/religions` → lien Religions actif, liste des 16 religions dépliée, aucune en surbrillance
- [ ] Cliquer "Foedus Animae" dans le sous-arbre → URL `#md/Lore/Religions/Foedus%20Animae.md`, page rendue, sidebar met Foedus en surbrillance
- [ ] Sur la route `#md/Lore/Religions/Taciti.md` (mineure) → Taciti en surbrillance et toujours en italique atténué
- [ ] Sur `#mecaniques/combat` (route non-religion / non-nation) → comportement classique du lore-nav, pas de sous-arbre injecté

---
_Generated by [Claude Code](https://claude.ai/code/session_017VU1nozRH6vuqMWQFURZn6)_