### PR TITLE
Graphe de connaissances canonique : cœur, API, Atelier, migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,12 @@ local-history.json
 local-borders.json
 local-highlights.json
 
+# Base locale du graphe de connaissances (node:sqlite — miroir dev de Turso)
+local-kg.sqlite
+local-kg.sqlite-*
+local-kg.sqlite-shm
+local-kg.sqlite-wal
+
 # Config éditeur Obsidian — ne doit pas être servie publiquement
 Docs/Lore/.obsidian/
 

--- a/api/kg.js
+++ b/api/kg.js
@@ -1,0 +1,76 @@
+'use strict';
+/*
+ * api/kg.js — Point d'entrée serverless (Vercel) du graphe de connaissances.
+ *
+ * La logique vit dans lib/kg-core.js (backend-agnostique). Ici on ne fait que :
+ *   1. fournir l'adaptateur de stockage Turso (exec SQL via HTTP /v2/pipeline) ;
+ *   2. router les requêtes GET (lectures / projections) et POST (écritures) ;
+ *   3. protéger l'accès par EDITOR_PASSWORD — le site est privé.
+ *
+ * Le MÊME cœur est câblé en développement dans server.js sur node:sqlite.
+ */
+
+const kg = require('../lib/kg-core.js');
+const { createTursoExec } = require('../lib/turso-adapter.js');
+
+const TURSO_URL = process.env.TURSO_URL;
+const TURSO_TOKEN = process.env.TURSO_AUTH_TOKEN;
+
+let _exec = null;
+function getExec() {
+  if (!_exec) _exec = createTursoExec(TURSO_URL, TURSO_TOKEN);
+  return _exec;
+}
+
+let schemaReady = false;
+async function ensureSchema(exec) {
+  if (schemaReady) return;
+  await kg.initSchema(exec);
+  schemaReady = true;
+}
+
+// ── Handler ─────────────────────────────────────────────────────────────────
+module.exports = async function handler(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-Editor-Password');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  if (!TURSO_URL || !TURSO_TOKEN) {
+    return res.status(500).json({ error: 'Turso non configuré (TURSO_URL / TURSO_AUTH_TOKEN).' });
+  }
+
+  const exec = getExec();
+  const PASSWORD = process.env.EDITOR_PASSWORD;
+
+  try {
+    await ensureSchema(exec);
+
+    // ── Lectures (GET) — le site est privé : mot de passe requis (header) ──
+    if (req.method === 'GET') {
+      const provided = req.headers['x-editor-password'];
+      if (!PASSWORD || provided !== PASSWORD) {
+        return res.status(403).json({ error: 'Mot de passe requis (header X-Editor-Password)' });
+      }
+      const out = await kg.readAction(exec, req.query.action || 'list', req.query);
+      return res.status(200).json(out);
+    }
+
+    // ── Écritures (POST) — mot de passe dans le corps ─────────────────────
+    if (req.method === 'POST') {
+      const { password, action, data } = req.body || {};
+      if (!PASSWORD || password !== PASSWORD) {
+        return res.status(403).json({ error: 'Mot de passe incorrect' });
+      }
+      const out = await kg.writeAction(exec, action, data);
+      return res.status(200).json(out);
+    }
+
+    return res.status(405).json({ error: 'Method not allowed' });
+  } catch (err) {
+    const code = err && err.code ? err.code : 'error';
+    const status = code === 'validation' || code === 'ref' || code === 'referenced' ? 400
+      : code === 'not-found' ? 404 : 500;
+    return res.status(status).json({ error: err.message, code });
+  }
+};

--- a/atelier.html
+++ b/atelier.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex, nofollow" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ctext y='13' font-size='13'%3E%E2%9C%A6%3C/text%3E%3C/svg%3E" />
+  <title>Atelier — Graphe canonique d'Hybélior</title>
+  <style>
+    :root {
+      --bg: #12100e; --panel: #1b1814; --panel2: #221e19; --line: #332c23;
+      --ink: #e8dfd1; --dim: #a89a86; --faint: #7a6f5f;
+      --gold: #c9a24b; --gold-soft: #e0c274; --accent: #6a8caf;
+      --ok: #6fae72; --warn: #d1a24b; --err: #cf6b5a;
+      --radius: 8px;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body {
+      background: var(--bg); color: var(--ink);
+      font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      display: flex; flex-direction: column; height: 100vh; overflow: hidden;
+    }
+    a { color: var(--gold-soft); text-decoration: none; cursor: pointer; }
+    a:hover { text-decoration: underline; }
+    button {
+      font: inherit; cursor: pointer; border: 1px solid var(--line);
+      background: var(--panel2); color: var(--ink); padding: 6px 12px;
+      border-radius: 6px; transition: background .12s, border-color .12s;
+    }
+    button:hover { background: #2c2620; border-color: var(--gold); }
+    button.primary { background: var(--gold); color: #1a1712; border-color: var(--gold); font-weight: 600; }
+    button.primary:hover { background: var(--gold-soft); }
+    button.danger:hover { border-color: var(--err); color: var(--err); }
+    button.ghost { background: transparent; }
+    input, select, textarea {
+      font: inherit; background: #100e0b; color: var(--ink);
+      border: 1px solid var(--line); border-radius: 6px; padding: 7px 9px; width: 100%;
+    }
+    input:focus, select:focus, textarea:focus { outline: none; border-color: var(--gold); }
+    textarea { resize: vertical; min-height: 60px; }
+    label { display: block; font-size: 12px; color: var(--dim); margin: 10px 0 4px; text-transform: uppercase; letter-spacing: .04em; }
+    .badge {
+      display: inline-block; font-size: 11px; padding: 1px 7px; border-radius: 20px;
+      background: #2a2419; color: var(--gold-soft); border: 1px solid var(--line); white-space: nowrap;
+    }
+    .badge.st-canon { color: var(--ok); } .badge.st-rumeur { color: var(--faint); }
+    .badge.st-lecture-disputee { color: var(--warn); } .badge.st-retconne { color: var(--err); text-decoration: line-through; }
+    .muted { color: var(--dim); } .faint { color: var(--faint); }
+    .row { display: flex; gap: 8px; align-items: center; }
+    .grow { flex: 1; }
+
+    /* ── Topbar ── */
+    header {
+      display: flex; align-items: center; gap: 16px; padding: 10px 18px;
+      background: linear-gradient(180deg, #1d1915, #171310); border-bottom: 1px solid var(--line);
+    }
+    header h1 { font-size: 16px; margin: 0; font-weight: 600; letter-spacing: .02em; }
+    header h1 .g { color: var(--gold); }
+    #stats { display: flex; gap: 6px; flex-wrap: wrap; margin-left: auto; }
+    #stats .badge { background: transparent; }
+
+    /* ── Layout ── */
+    main { flex: 1; display: flex; min-height: 0; }
+    #sidebar {
+      width: 320px; border-right: 1px solid var(--line); display: flex; flex-direction: column;
+      background: var(--panel);
+    }
+    #sidebar .tools { padding: 12px; border-bottom: 1px solid var(--line); display: flex; flex-direction: column; gap: 8px; }
+    #typeFilter { display: flex; flex-wrap: wrap; gap: 4px; }
+    #typeFilter .chip {
+      font-size: 11px; padding: 2px 8px; border-radius: 20px; border: 1px solid var(--line);
+      background: transparent; color: var(--dim); cursor: pointer;
+    }
+    #typeFilter .chip.active { background: var(--gold); color: #1a1712; border-color: var(--gold); }
+    #entityList { flex: 1; overflow-y: auto; }
+    .ent {
+      padding: 8px 12px; border-bottom: 1px solid #241f19; cursor: pointer;
+      display: flex; justify-content: space-between; gap: 8px; align-items: center;
+    }
+    .ent:hover { background: var(--panel2); }
+    .ent.sel { background: #2a2318; border-left: 3px solid var(--gold); }
+    .ent .nm { font-weight: 500; }
+    .ent .ty { font-size: 10px; color: var(--faint); }
+
+    #detail { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+    #tabs { display: flex; gap: 2px; padding: 0 14px; border-bottom: 1px solid var(--line); background: var(--panel); }
+    #tabs .tab { padding: 11px 16px; cursor: pointer; color: var(--dim); border-bottom: 2px solid transparent; font-size: 14px; }
+    #tabs .tab.active { color: var(--gold-soft); border-bottom-color: var(--gold); }
+    #view { flex: 1; overflow-y: auto; padding: 20px 26px; }
+
+    .section { margin-bottom: 26px; }
+    .section > h3 {
+      font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--gold);
+      border-bottom: 1px solid var(--line); padding-bottom: 5px; margin: 0 0 10px;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .item { padding: 7px 0; border-bottom: 1px solid #221d17; display: flex; gap: 10px; align-items: baseline; }
+    .item:last-child { border-bottom: none; }
+    .item .when { color: var(--gold-soft); font-variant-numeric: tabular-nums; min-width: 120px; font-size: 13px; }
+    .item .what { flex: 1; }
+    .item .x { color: var(--faint); cursor: pointer; font-size: 12px; }
+    .item .x:hover { color: var(--err); }
+    .card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 16px; }
+
+    .fiche-head { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 8px; }
+    .fiche-head h2 { margin: 0; font-size: 26px; font-weight: 600; }
+    .fiche-head .sub { color: var(--dim); }
+
+    /* ── Modal ── */
+    #overlay {
+      position: fixed; inset: 0; background: rgba(6,5,4,.72); display: none;
+      align-items: center; justify-content: center; z-index: 50; padding: 20px;
+    }
+    #overlay.on { display: flex; }
+    .modal {
+      background: var(--panel2); border: 1px solid var(--gold); border-radius: 12px;
+      width: 560px; max-width: 100%; max-height: 88vh; overflow-y: auto; padding: 22px;
+      box-shadow: 0 20px 60px rgba(0,0,0,.6);
+    }
+    .modal h2 { margin: 0 0 4px; font-size: 19px; }
+    .modal .actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 20px; }
+    .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; }
+
+    /* ── Entity picker ── */
+    .picker { position: relative; }
+    .picker .results {
+      position: absolute; top: 100%; left: 0; right: 0; background: #17130f;
+      border: 1px solid var(--gold); border-radius: 6px; max-height: 220px; overflow-y: auto; z-index: 5; display: none;
+    }
+    .picker .results.on { display: block; }
+    .picker .results .r { padding: 6px 10px; cursor: pointer; display: flex; justify-content: space-between; }
+    .picker .results .r:hover { background: #2a2318; }
+    .chosen { font-size: 12px; color: var(--ok); margin-top: 3px; min-height: 16px; }
+
+    /* ── Coherence ── */
+    .issue { padding: 8px 12px; border-radius: 6px; margin-bottom: 6px; border-left: 3px solid var(--line); background: var(--panel); }
+    .issue.erreur { border-left-color: var(--err); } .issue.avert { border-left-color: var(--warn); } .issue.info { border-left-color: var(--accent); }
+    .issue .k { font-size: 10px; text-transform: uppercase; color: var(--faint); letter-spacing: .05em; }
+
+    .empty { color: var(--faint); text-align: center; padding: 60px 20px; font-style: italic; }
+    .toast {
+      position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
+      background: #1e2b1e; border: 1px solid var(--ok); color: var(--ink); padding: 10px 18px;
+      border-radius: 8px; z-index: 100; opacity: 0; transition: opacity .2s; pointer-events: none;
+    }
+    .toast.err { background: #2b1c1a; border-color: var(--err); }
+    .toast.on { opacity: 1; }
+    .hint { font-size: 12px; color: var(--faint); margin-top: 3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Atelier · <span class="g">Graphe canonique d'Hybélior</span></h1>
+    <div id="stats" class="muted"></div>
+    <button id="btnCoherence" class="ghost" title="Vérifier la cohérence">✓ Cohérence</button>
+    <button id="btnLogout" class="ghost" title="Se déverrouiller">⏻</button>
+  </header>
+
+  <main>
+    <aside id="sidebar">
+      <div class="tools">
+        <input id="search" type="search" placeholder="Rechercher (nom ou nom historique)…" autocomplete="off" />
+        <div id="typeFilter"></div>
+        <button id="btnNew" class="primary">＋ Nouvelle entité</button>
+      </div>
+      <div id="entityList"></div>
+    </aside>
+
+    <section id="detail">
+      <div id="tabs">
+        <div class="tab active" data-tab="fiche">Fiche</div>
+        <div class="tab" data-tab="chronologie">Chronologie</div>
+        <div class="tab" data-tab="dirigeants">Dirigeants</div>
+        <div class="tab" data-tab="coherence">Cohérence</div>
+      </div>
+      <div id="view"></div>
+    </section>
+  </main>
+
+  <div id="overlay"><div class="modal" id="modal"></div></div>
+  <div id="toast" class="toast"></div>
+
+  <script src="/js/atelier.js"></script>
+</body>
+</html>

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,72 @@
+# Le graphe de connaissances canonique d'Hybélior
+
+Le **site est la source de vérité unique** de l'univers. Chaque information
+(personne, empire, ville, événement, concept, religion, espèce, objet…)
+n'existe qu'à **un seul endroit** — une ligne du graphe — et est *projetée*
+partout ailleurs : fiche, chronologie, arbre, liste de dirigeants, carte.
+La non-duplication n'est pas une discipline : elle est structurelle.
+
+```
+      TU ÉDITES DANS L'ATELIER            STOCKÉ                 PROJETÉ
+   ┌───────────────────────────┐   ┌──────────────────┐   ┌──────────────────┐
+   │  /atelier.html            │   │  Turso (prod)    │   │  Fiche            │
+   │  (éditeur + projections)  │──▶│  node:sqlite(dev)│──▶│  Chronologie      │
+   │  privé, pour l'auteur      │   │  = MÊME schéma    │   │  Dirigeants       │
+   └───────────────────────────┘   └──────────────────┘   │  Cohérence        │
+              │  /api/kg (lib/kg-core.js)                  └──────────────────┘
+```
+
+## Les pièces
+
+| Fichier | Rôle |
+|---|---|
+| `lib/kg-core.js` | **Le cœur** — schéma, catalogues, validation, cohérence, projections. Backend-agnostique. Toute la logique vit ici, écrite une seule fois. |
+| `lib/turso-adapter.js` | Adaptateur de stockage Turso (production, via HTTP). |
+| `lib/sqlite-adapter.js` | Adaptateur `node:sqlite` (dev + seed). Le **même SQL** que Turso. |
+| `api/kg.js` | Fonction serverless Vercel — route les lectures/écritures, protège par mot de passe. |
+| `server.js` | Serveur de dev — expose `/api/kg` sur `node:sqlite`. |
+| `atelier.html` + `js/atelier.js` | L'Atelier : l'interface d'édition et de consultation. |
+| `scripts/migrate-kg.js` | Seed initial depuis `data/timeline-names.json`. |
+| `db/schema.sql` | Instantané lisible du schéma (régénéré par `npm run kg:schema`). |
+
+## Le modèle
+
+- **Identité stable** : chaque entité a un `id` opaque et permanent (`per-0001`,
+  `pol-0042`…), **jamais** son nom d'affichage. Renommer une entité ne casse
+  aucune référence — c'est ce qui protège les renommages et les homonymies.
+- **Noms datés** (`kg_aliases`) : un nom a une période de validité (`from_year`,
+  `to_year`) et un statut (`visible`, `predecessor`, `vanished`…).
+- **Faits datés** (`kg_facts`) : naissance, mort, règne, fondation, chute,
+  frontière… avec date-objet (`start_year`, `precision`, `circa`), ordre de
+  départage (`seq`), provenance (`source_id`) et statut épistémique.
+- **Relations** (`kg_relations`) typées et dirigées, saisies une seule fois
+  (l'arête inverse est calculée à la projection).
+- **Mystères protégés** : entités `question` portant plusieurs **lectures
+  concurrentes** (`kg_readings`) qu'on ne collapse jamais en un fait unique.
+- **Statut épistémique** partout : `canon` › `lecture-disputee` › `rumeur` ›
+  `retconne`. Le graphe dit ce qu'on sait *et* à quel degré.
+
+## Cohérence garantie
+
+L'onglet **Cohérence** (et `getConsistencyReport`) scanne tout le graphe :
+intégrité référentielle (aucun lien vers le vide), cohérence de vie (nul ne
+meurt avant de naître), continuité des successions (ni trou ni chevauchement),
+provenance du canon, sanctuaire des mystères. Une contradiction est *visible*,
+jamais silencieuse.
+
+## Lancer en local
+
+```bash
+npm run dev              # sert le site + /api/kg sur node:sqlite (local-kg.sqlite)
+npm run kg:migrate       # (optionnel) seed depuis timeline-names.json  [--reset]
+# ouvrir http://localhost:3001/atelier.html  — mot de passe : EDITOR_PASSWORD (défaut « local »)
+```
+
+## Production (Vercel + Turso)
+
+Variables d'environnement : `TURSO_URL`, `TURSO_AUTH_TOKEN`, `EDITOR_PASSWORD`.
+Le schéma se crée tout seul au premier appel (`initSchema`). Pour semer la base
+Turso, lancer la migration avec ces variables présentes.
+
+> Le graphe est **privé** : l'Atelier et l'API `/api/kg` exigent le mot de passe
+> (en-tête `X-Editor-Password` en lecture, corps en écriture).

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,109 @@
+-- db/schema.sql — Schéma du graphe de connaissances canonique d Hybélior.
+--
+-- ⚠ SOURCE DE VÉRITÉ : lib/kg-core.js (constante SCHEMA_STATEMENTS).
+-- Ce fichier est un instantané lisible, régénéré par : npm run kg:schema
+-- Le même DDL est appliqué en production (Turso/libSQL) et en dev (node:sqlite).
+
+CREATE TABLE IF NOT EXISTS kg_entities (
+  id         TEXT PRIMARY KEY,
+  type       TEXT NOT NULL,
+  name       TEXT NOT NULL,
+  slug       TEXT,
+  summary    TEXT,
+  body       TEXT,
+  data       TEXT,
+  status     TEXT NOT NULL DEFAULT 'canon',
+  disclosure TEXT NOT NULL DEFAULT 'interne',
+  created_at TEXT,
+  updated_at TEXT
+  );
+
+CREATE INDEX IF NOT EXISTS idx_kg_entities_type ON kg_entities(type);
+
+CREATE INDEX IF NOT EXISTS idx_kg_entities_name ON kg_entities(name);
+
+CREATE TABLE IF NOT EXISTS kg_aliases (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  entity_id    TEXT NOT NULL,
+  value        TEXT NOT NULL,
+  alias_status TEXT NOT NULL DEFAULT 'visible',
+  era_id       TEXT,
+  from_year    INTEGER,
+  to_year      INTEGER,
+  meaning      TEXT,
+  UNIQUE(entity_id, value, era_id)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_kg_aliases_entity ON kg_aliases(entity_id);
+
+CREATE INDEX IF NOT EXISTS idx_kg_aliases_value ON kg_aliases(value);
+
+CREATE TABLE IF NOT EXISTS kg_facts (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  fact_type       TEXT NOT NULL,
+  subject_id      TEXT NOT NULL,
+  object_id       TEXT,
+  start_year      INTEGER,
+  start_precision TEXT DEFAULT 'annee',
+  start_circa     INTEGER DEFAULT 0,
+  end_year        INTEGER,
+  end_precision   TEXT,
+  end_circa       INTEGER DEFAULT 0,
+  era_id          TEXT,
+  seq             INTEGER DEFAULT 0,
+  label           TEXT,
+  detail          TEXT,
+  data            TEXT,
+  source_id       TEXT,
+  status          TEXT NOT NULL DEFAULT 'canon',
+  disclosure      TEXT NOT NULL DEFAULT 'interne',
+  created_at      TEXT,
+  updated_at      TEXT
+  );
+
+CREATE INDEX IF NOT EXISTS idx_kg_facts_subject ON kg_facts(subject_id);
+
+CREATE INDEX IF NOT EXISTS idx_kg_facts_object ON kg_facts(object_id);
+
+CREATE INDEX IF NOT EXISTS idx_kg_facts_year ON kg_facts(start_year);
+
+CREATE INDEX IF NOT EXISTS idx_kg_facts_type ON kg_facts(fact_type);
+
+CREATE TABLE IF NOT EXISTS kg_relations (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  rel_type   TEXT NOT NULL,
+  from_id    TEXT NOT NULL,
+  to_id      TEXT NOT NULL,
+  start_year INTEGER,
+  end_year   INTEGER,
+  label      TEXT,
+  data       TEXT,
+  source_id  TEXT,
+  status     TEXT NOT NULL DEFAULT 'canon',
+  UNIQUE(rel_type, from_id, to_id, start_year)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_from ON kg_relations(from_id);
+
+CREATE INDEX IF NOT EXISTS idx_kg_relations_to ON kg_relations(to_id);
+
+CREATE TABLE IF NOT EXISTS kg_readings (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  question_id    TEXT NOT NULL,
+  text           TEXT NOT NULL,
+  source_id      TEXT,
+  reading_status TEXT DEFAULT 'lecture-sourcee',
+  ordinal        INTEGER DEFAULT 0
+  );
+
+CREATE INDEX IF NOT EXISTS idx_kg_readings_q ON kg_readings(question_id);
+
+CREATE TABLE IF NOT EXISTS kg_audit (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  ref_id     TEXT,
+  kind       TEXT,
+  op         TEXT,
+  before     TEXT,
+  after      TEXT,
+  changed_at TEXT
+  );

--- a/js/atelier.js
+++ b/js/atelier.js
@@ -1,0 +1,533 @@
+'use strict';
+/*
+ * js/atelier.js — L'Atelier : éditeur + projections du graphe canonique.
+ *
+ * Surface personnelle (privée) où le SITE est la source de vérité. Chaque
+ * information est saisie une seule fois puis projetée : fiche, chronologie,
+ * liste de dirigeants, cohérence. Parle à /api/kg (même cœur Turso/node:sqlite).
+ */
+
+// ── Petit hyperscript sûr (textContent pour les données utilisateur) ─────────
+function h(tag, attrs, ...kids) {
+  const e = document.createElement(tag);
+  if (attrs) for (const [k, v] of Object.entries(attrs)) {
+    if (v == null || v === false) continue;
+    if (k === 'class') e.className = v;
+    else if (k === 'text') e.textContent = v;
+    else if (k === 'html') e.innerHTML = v;
+    else if (k.startsWith('on') && typeof v === 'function') e.addEventListener(k.slice(2), v);
+    else if (k === 'value') e.value = v;
+    else e.setAttribute(k, v);
+  }
+  for (const kid of kids.flat()) {
+    if (kid == null || kid === false) continue;
+    e.append(kid.nodeType ? kid : document.createTextNode(String(kid)));
+  }
+  return e;
+}
+const $ = (s, r = document) => r.querySelector(s);
+
+// ── Client API ───────────────────────────────────────────────────────────────
+const KG = {
+  pw: sessionStorage.getItem('kgpw') || '',
+  async get(action, params = {}) {
+    const clean = {}; for (const [k, v] of Object.entries(params)) if (v !== '' && v != null) clean[k] = v;
+    const qs = new URLSearchParams(Object.assign({ action }, clean)).toString();
+    const r = await fetch('/api/kg?' + qs, { headers: { 'X-Editor-Password': this.pw } });
+    if (r.status === 403) { const e = new Error('auth'); e.auth = true; throw e; }
+    const j = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(j.error || ('Erreur ' + r.status));
+    return j;
+  },
+  async post(action, data) {
+    const r = await fetch('/api/kg', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: this.pw, action, data }),
+    });
+    if (r.status === 403) { const e = new Error('auth'); e.auth = true; throw e; }
+    const j = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error(j.error || ('Erreur ' + r.status));
+    return j;
+  },
+};
+
+// ── État ─────────────────────────────────────────────────────────────────────
+const S = { catalog: null, filterType: '', search: '', selectedId: null, tab: 'fiche', entities: [] };
+
+// ── Toast ─────────────────────────────────────────────────────────────────────
+let toastT;
+function toast(msg, isErr) {
+  const t = $('#toast'); t.textContent = msg; t.className = 'toast on' + (isErr ? ' err' : '');
+  clearTimeout(toastT); toastT = setTimeout(() => (t.className = 'toast'), 2600);
+}
+async function guard(fn) { try { return await fn(); } catch (e) { if (e.auth) return askPassword(); toast(e.message, true); throw e; } }
+
+// ── Verrou ─────────────────────────────────────────────────────────────────────
+function askPassword() {
+  openModal(h('div', {},
+    h('h2', { text: 'Atelier verrouillé' }),
+    h('p', { class: 'muted', text: 'Le graphe est privé. Entre le mot de passe d’édition.' }),
+    h('input', { id: 'pwField', type: 'password', placeholder: 'Mot de passe', onkeydown: (e) => { if (e.key === 'Enter') submitPw(); } }),
+    h('div', { class: 'actions' }, h('button', { class: 'primary', onclick: submitPw, text: 'Déverrouiller' })),
+  ));
+  setTimeout(() => $('#pwField') && $('#pwField').focus(), 30);
+}
+async function submitPw() {
+  KG.pw = $('#pwField').value;
+  try { await KG.get('stats'); sessionStorage.setItem('kgpw', KG.pw); closeModal(); boot(); }
+  catch { toast('Mot de passe incorrect', true); }
+}
+
+// ── Modal ─────────────────────────────────────────────────────────────────────
+function openModal(node) { const m = $('#modal'); m.innerHTML = ''; m.append(node); $('#overlay').classList.add('on'); }
+function closeModal() { $('#overlay').classList.remove('on'); }
+$('#overlay').addEventListener('click', (e) => { if (e.target.id === 'overlay') closeModal(); });
+
+// ── Sélecteurs ─────────────────────────────────────────────────────────────────
+function selectFrom(list, value, id) {
+  return h('select', { id },
+    ...list.map(v => { const o = h('option', { value: v, text: v }); if (v === value) o.selected = true; return o; }));
+}
+
+// ── Entity picker (référence par id, recherche par nom/alias) ──────────────────
+function makePicker(initialId, initialLabel, placeholder) {
+  let value = initialId || '';
+  const input = h('input', { type: 'text', placeholder: placeholder || 'Rechercher une entité…', autocomplete: 'off' });
+  const results = h('div', { class: 'results' });
+  const chosen = h('div', { class: 'chosen', text: initialLabel ? `→ ${initialLabel}` : '' });
+  const wrap = h('div', { class: 'picker' }, input, results, chosen);
+  let t;
+  input.addEventListener('input', () => {
+    clearTimeout(t);
+    const term = input.value.trim();
+    if (!term) { results.classList.remove('on'); value = ''; chosen.textContent = ''; return; }
+    t = setTimeout(async () => {
+      try {
+        const { entities } = await KG.get('list', { search: term });
+        results.innerHTML = '';
+        entities.slice(0, 30).forEach(e => {
+          results.append(h('div', { class: 'r', onclick: () => { value = e.id; chosen.textContent = `→ ${e.name}`; input.value = e.name; results.classList.remove('on'); } },
+            h('span', { text: e.name }), h('span', { class: 'ty faint', text: e.type })));
+        });
+        results.classList.add('on');
+      } catch { /* silencieux */ }
+    }, 180);
+  });
+  document.addEventListener('click', (e) => { if (!wrap.contains(e.target)) results.classList.remove('on'); });
+  return { element: wrap, get: () => value || null, clear: () => { value = ''; input.value = ''; chosen.textContent = ''; } };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SIDEBAR
+// ═══════════════════════════════════════════════════════════════════════════════
+function renderTypeFilter() {
+  const box = $('#typeFilter'); box.innerHTML = '';
+  const mk = (val, lbl) => h('span', { class: 'chip' + (S.filterType === val ? ' active' : ''), text: lbl, onclick: () => { S.filterType = val; renderTypeFilter(); loadEntities(); } });
+  box.append(mk('', 'tous'));
+  S.catalog.entityTypes.forEach(t => box.append(mk(t, t)));
+}
+async function loadEntities() {
+  const { entities } = await guard(() => KG.get('list', { type: S.filterType, search: S.search }));
+  S.entities = entities || [];
+  const list = $('#entityList'); list.innerHTML = '';
+  if (!S.entities.length) { list.append(h('div', { class: 'empty', text: 'Aucune entité.' })); return; }
+  S.entities.forEach(e => {
+    list.append(h('div', { class: 'ent' + (e.id === S.selectedId ? ' sel' : ''), onclick: () => selectEntity(e.id) },
+      h('div', {}, h('div', { class: 'nm', text: e.name }), h('span', { class: 'ty', text: e.id + ' · ' + e.type })),
+      e.status && e.status !== 'canon' ? h('span', { class: 'badge st-' + e.status, text: e.status }) : null));
+  });
+}
+async function refreshStats() {
+  const { stats } = await guard(() => KG.get('stats'));
+  const s = $('#stats'); s.innerHTML = '';
+  s.append(h('span', { class: 'badge', text: stats.entities + ' entités' }));
+  s.append(h('span', { class: 'badge', text: stats.facts + ' faits' }));
+  s.append(h('span', { class: 'badge', text: stats.relations + ' relations' }));
+  s.append(h('span', { class: 'badge', text: stats.aliases + ' noms' }));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// TABS
+// ═══════════════════════════════════════════════════════════════════════════════
+document.querySelectorAll('#tabs .tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    document.querySelectorAll('#tabs .tab').forEach(t => t.classList.remove('active'));
+    tab.classList.add('active'); S.tab = tab.dataset.tab; renderView();
+  });
+});
+function renderView() {
+  if (S.tab === 'fiche') renderFiche();
+  else if (S.tab === 'chronologie') renderChronologie();
+  else if (S.tab === 'dirigeants') renderDirigeants();
+  else if (S.tab === 'coherence') renderCoherence();
+}
+function selectEntity(id) {
+  S.selectedId = id; S.tab = 'fiche';
+  document.querySelectorAll('#tabs .tab').forEach(t => t.classList.toggle('active', t.dataset.tab === 'fiche'));
+  loadEntities(); renderFiche();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FICHE (dossier)
+// ═══════════════════════════════════════════════════════════════════════════════
+async function renderFiche() {
+  const view = $('#view');
+  if (!S.selectedId) { view.innerHTML = ''; view.append(h('div', { class: 'empty', text: 'Sélectionne une entité à gauche, ou crée-en une.' })); return; }
+  const { dossier } = await guard(() => KG.get('dossier', { id: S.selectedId }));
+  if (!dossier) { view.innerHTML = ''; view.append(h('div', { class: 'empty', text: 'Entité introuvable.' })); return; }
+  const e = dossier.entity;
+  view.innerHTML = '';
+
+  // En-tête
+  view.append(h('div', { class: 'fiche-head' },
+    h('div', { class: 'grow' },
+      h('h2', { text: e.name }),
+      h('div', { class: 'sub' }, h('span', { class: 'badge', text: e.type }), ' ',
+        e.data && e.data.echelle ? h('span', { class: 'badge', text: e.data.echelle }) : null, ' ',
+        e.data && e.data.rang ? h('span', { class: 'badge', text: e.data.rang }) : null, ' ',
+        h('span', { class: 'badge st-' + e.status, text: e.status }), ' ',
+        h('span', { class: 'faint', text: '· ' + e.id }))),
+    h('div', { class: 'row' },
+      h('button', { onclick: () => entityForm(e), text: '✎ Éditer' }),
+      h('button', { class: 'danger', onclick: () => deleteEntity(e), text: '🗑' }))));
+
+  if (e.summary) view.append(h('p', { class: 'muted', text: e.summary }));
+  if (e.body) view.append(h('div', { class: 'card', style: 'white-space:pre-wrap; margin-bottom:22px', text: e.body }));
+
+  // Noms / alias
+  view.append(section('Noms datés', () => aliasForm(e.id),
+    dossier.aliases.length
+      ? dossier.aliases.map(a => item(
+          yearsLabel(a.from_year, a.to_year),
+          [h('strong', { text: a.value }), ' ', h('span', { class: 'badge', text: a.alias_status }),
+           a.meaning ? h('span', { class: 'faint', text: ' — ' + a.meaning } ) : null],
+          () => del('delete-alias', a.id)))
+      : [emptyRow('Aucun nom historique.')]));
+
+  // Faits
+  view.append(section('Faits datés', () => factForm(e.id),
+    dossier.facts.length
+      ? dossier.facts.map(f => item(
+          f.dateLabel,
+          [h('strong', { text: f.fact_type }), ' ',
+           f.role === 'objet' ? h('span', { class: 'faint', text: `(${f.subjectName} →) ` }) : null,
+           f.label ? h('span', { text: f.label + ' ' }) : null,
+           f.objectName ? h('span', { class: 'muted', text: '@ ' + f.objectName + ' ' }) : null,
+           f.status !== 'canon' ? h('span', { class: 'badge st-' + f.status, text: f.status }) : null,
+           f.sourceName ? h('span', { class: 'faint', text: ' · ' + f.sourceName }) : null],
+          () => del('delete-fact', f.id),
+          () => factForm(e.id, f)))
+      : [emptyRow('Aucun fait.')]));
+
+  // Relations
+  view.append(section('Relations', () => relationForm(e.id),
+    dossier.relations.length
+      ? dossier.relations.map(r => item(
+          h('span', { class: 'badge', text: r.direction === 'entrante' ? '←' : '→' }),
+          [h('span', { text: r.label + ' ' }), h('a', { onclick: () => selectEntity(r.otherId), text: r.otherName }),
+           (r.start_year != null || r.end_year != null) ? h('span', { class: 'faint', text: ' ' + yearsLabel(r.start_year, r.end_year) }) : null],
+          r.direction === 'sortante' ? () => del('delete-relation', r.id) : null))
+      : [emptyRow('Aucune relation.')]));
+
+  // Lectures (mystère)
+  if (e.type === 'question') {
+    view.append(section('Lectures concurrentes' + (e.data && e.data.protege ? ' · 🔒 protégé' : ''), () => readingForm(e.id),
+      dossier.readings.length
+        ? dossier.readings.map(rd => item(
+            '№ ' + (rd.ordinal || '—'),
+            [h('span', { text: rd.text }), ' ', h('span', { class: 'badge', text: rd.reading_status }),
+             rd.sourceName ? h('span', { class: 'faint', text: ' · ' + rd.sourceName }) : null],
+            () => del('delete-reading', rd.id)))
+        : [emptyRow('Aucune lecture — un mystère protégé doit en garder au moins deux.')]));
+  }
+}
+
+function section(title, onAdd, rows) {
+  return h('div', { class: 'section' },
+    h('h3', {}, h('span', { text: title }), onAdd ? h('button', { class: 'ghost', onclick: onAdd, text: '＋ ajouter' }) : null),
+    ...rows);
+}
+function item(when, whatKids, onDel, onEdit) {
+  return h('div', { class: 'item' },
+    h('div', { class: 'when' }, when),
+    h('div', { class: 'what' }, ...(Array.isArray(whatKids) ? whatKids : [whatKids])),
+    onEdit ? h('span', { class: 'x', onclick: onEdit, text: '✎' }) : null,
+    onDel ? h('span', { class: 'x', onclick: onDel, text: '✕' }) : null);
+}
+function emptyRow(txt) { return h('div', { class: 'item' }, h('div', { class: 'faint', text: txt })); }
+function yearsLabel(a, b) {
+  const f = (y) => y == null ? '?' : (y < 0 ? Math.abs(y) + ' av.A' : y + ' ap.A');
+  if (a == null && b == null) return '—';
+  return f(a) + ' → ' + f(b);
+}
+async function del(action, id) {
+  if (!confirm('Supprimer cet élément ?')) return;
+  await guard(() => KG.post(action, { id }));
+  toast('Supprimé'); renderFiche(); refreshStats();
+}
+async function deleteEntity(e) {
+  if (!confirm(`Supprimer l’entité « ${e.name} » ?`)) return;
+  try { await KG.post('delete-entity', { id: e.id }); toast('Entité supprimée'); S.selectedId = null; loadEntities(); refreshStats(); renderFiche(); }
+  catch (err) { toast(err.message, true); }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// FORMULAIRES
+// ═══════════════════════════════════════════════════════════════════════════════
+function field(label, control, hint) {
+  return h('div', {}, h('label', { text: label }), control, hint ? h('div', { class: 'hint', text: hint }) : null);
+}
+
+function entityForm(existing) {
+  const c = S.catalog;
+  const typeSel = selectFrom(c.entityTypes, existing ? existing.type : 'personne');
+  const name = h('input', { value: existing ? existing.name : '', placeholder: 'Nom courant' });
+  const summary = h('textarea', { placeholder: 'Résumé court' }); if (existing && existing.summary) summary.value = existing.summary;
+  const body = h('textarea', { placeholder: 'Corps (notes longues)', style: 'min-height:120px' }); if (existing && existing.body) body.value = existing.body;
+  const status = selectFrom(c.statuses, existing ? existing.status : 'canon');
+  const disclosure = selectFrom(c.disclosures, existing ? existing.disclosure : 'interne');
+  const dataJson = h('textarea', { placeholder: '{ }  — échelle, rang, protege, continent…', style: 'min-height:52px' });
+  dataJson.value = existing && existing.data ? JSON.stringify(existing.data) : '';
+
+  openModal(h('div', {},
+    h('h2', { text: existing ? 'Éditer l’entité' : 'Nouvelle entité' }),
+    h('div', { class: 'grid2' }, field('Type', typeSel), field('Statut', status)),
+    field('Nom', name),
+    field('Résumé', summary),
+    field('Corps', body),
+    h('div', { class: 'grid2' }, field('Divulgation', disclosure), field('Données (JSON)', dataJson, 'ex : {"echelle":"nation"} · {"protege":true}')),
+    h('div', { class: 'actions' },
+      h('button', { class: 'ghost', onclick: closeModal, text: 'Annuler' }),
+      h('button', { class: 'primary', text: 'Enregistrer', onclick: async () => {
+        let data = null;
+        if (dataJson.value.trim()) { try { data = JSON.parse(dataJson.value); } catch { return toast('JSON de données invalide', true); } }
+        const payload = { type: typeSel.value, name: name.value, summary: summary.value, body: body.value, status: status.value, disclosure: disclosure.value, data };
+        if (existing) payload.id = existing.id;
+        try {
+          const { entity } = await KG.post('save-entity', payload);
+          closeModal(); toast('Enregistré'); S.selectedId = entity.id; loadEntities(); refreshStats(); renderFiche();
+        } catch (e) { toast(e.message, true); }
+      } }))));
+}
+
+function factForm(subjectDefault, existing) {
+  const c = S.catalog;
+  const factType = selectFrom(c.factTypes, existing ? existing.fact_type : 'evenement');
+  const subject = makePicker(existing ? existing.subject_id : subjectDefault, null, 'Sujet');
+  const object = makePicker(existing ? existing.object_id : null, existing && existing.objectName, 'Objet (facultatif)');
+  const source = makePicker(existing ? existing.source_id : null, existing && existing.sourceName, 'Source (provenance)');
+  const sy = h('input', { type: 'number', placeholder: 'année (– = av.A)', value: existing && existing.start_year != null ? existing.start_year : '' });
+  const sp = selectFrom(c.precisions, existing ? existing.start_precision : 'annee');
+  const sc = h('input', { type: 'checkbox' }); if (existing && existing.start_circa) sc.checked = true;
+  const ey = h('input', { type: 'number', placeholder: 'fin (facultatif)', value: existing && existing.end_year != null ? existing.end_year : '' });
+  const ep = selectFrom(c.precisions, existing ? (existing.end_precision || 'annee') : 'annee');
+  const seq = h('input', { type: 'number', placeholder: '0', value: existing ? (existing.seq || 0) : 0 });
+  const era = h('input', { placeholder: 'era_id (ex : era6_nations)', value: existing && existing.era_id ? existing.era_id : '' });
+  const label = h('input', { placeholder: 'intitulé', value: existing && existing.label ? existing.label : '' });
+  const detail = h('textarea', { placeholder: 'détail' }); if (existing && existing.detail) detail.value = existing.detail;
+  const status = selectFrom(c.statuses, existing ? existing.status : 'canon');
+
+  openModal(h('div', {},
+    h('h2', { text: existing ? 'Éditer le fait' : 'Nouveau fait daté' }),
+    h('div', { class: 'grid2' }, field('Type de fait', factType), field('Statut', status)),
+    field('Sujet', subject.element),
+    field('Objet', object.element, 'ex : le règne d’un roi @ un empire'),
+    h('div', { class: 'grid2' },
+      field('Année de début', sy),
+      field('Précision', sp)),
+    h('div', { class: 'grid2' },
+      field('Approximatif (~)', sc),
+      field('Année de fin', ey)),
+    h('div', { class: 'grid2' }, field('Précision fin', ep), field('Ordre (seq)', seq)),
+    field('Intitulé', label),
+    field('Ère', era),
+    field('Source', source.element),
+    field('Détail', detail),
+    h('div', { class: 'actions' },
+      h('button', { class: 'ghost', onclick: closeModal, text: 'Annuler' }),
+      h('button', { class: 'primary', text: 'Enregistrer', onclick: async () => {
+        const payload = {
+          fact_type: factType.value, subject_id: subject.get(), object_id: object.get(),
+          start_year: sy.value === '' ? null : Number(sy.value), start_precision: sp.value, start_circa: sc.checked ? 1 : 0,
+          end_year: ey.value === '' ? null : Number(ey.value), end_precision: ep.value,
+          seq: Number(seq.value) || 0, era_id: era.value || null, label: label.value || null,
+          detail: detail.value || null, source_id: source.get(), status: status.value,
+        };
+        if (existing) payload.id = existing.id;
+        try { const r = await KG.post('save-fact', payload); closeModal(); toast(r.fact && r.fact._warning ? r.fact._warning : 'Fait enregistré'); renderFiche(); refreshStats(); }
+        catch (e) { toast(e.message, true); }
+      } }))));
+}
+
+function relationForm(fromDefault) {
+  const c = S.catalog;
+  const relType = selectFrom(c.relTypes, 'lie-a');
+  const from = makePicker(fromDefault, null, 'De…');
+  const to = makePicker(null, null, 'Vers…');
+  const source = makePicker(null, null, 'Source (facultatif)');
+  const sy = h('input', { type: 'number', placeholder: 'depuis (année)' });
+  const ey = h('input', { type: 'number', placeholder: 'jusqu’à (année)' });
+  const label = h('input', { placeholder: 'précision (facultatif)' });
+  const status = selectFrom(c.statuses, 'canon');
+  openModal(h('div', {},
+    h('h2', { text: 'Nouvelle relation' }),
+    field('Type', relType),
+    field('De', from.element),
+    field('Vers', to.element),
+    h('div', { class: 'grid2' }, field('Depuis', sy), field('Jusqu’à', ey)),
+    field('Intitulé', label),
+    h('div', { class: 'grid2' }, field('Statut', status), field('Source', source.element)),
+    h('div', { class: 'actions' },
+      h('button', { class: 'ghost', onclick: closeModal, text: 'Annuler' }),
+      h('button', { class: 'primary', text: 'Enregistrer', onclick: async () => {
+        try {
+          await KG.post('save-relation', { rel_type: relType.value, from_id: from.get(), to_id: to.get(),
+            start_year: sy.value === '' ? null : Number(sy.value), end_year: ey.value === '' ? null : Number(ey.value),
+            label: label.value || null, source_id: source.get(), status: status.value });
+          closeModal(); toast('Relation enregistrée'); renderFiche(); refreshStats();
+        } catch (e) { toast(e.message, true); }
+      } }))));
+}
+
+function aliasForm(entityId) {
+  const c = S.catalog;
+  const value = h('input', { placeholder: 'nom' });
+  const st = selectFrom(c.aliasStatuses, 'predecessor');
+  const fy = h('input', { type: 'number', placeholder: 'depuis (année)' });
+  const ty = h('input', { type: 'number', placeholder: 'jusqu’à (année)' });
+  const meaning = h('input', { placeholder: 'sens / note' });
+  const era = h('input', { placeholder: 'era_id (facultatif)' });
+  openModal(h('div', {},
+    h('h2', { text: 'Nouveau nom daté' }),
+    field('Nom', value),
+    h('div', { class: 'grid2' }, field('Statut', st), field('Ère', era)),
+    h('div', { class: 'grid2' }, field('Depuis', fy), field('Jusqu’à', ty)),
+    field('Sens', meaning),
+    h('div', { class: 'actions' },
+      h('button', { class: 'ghost', onclick: closeModal, text: 'Annuler' }),
+      h('button', { class: 'primary', text: 'Enregistrer', onclick: async () => {
+        try {
+          await KG.post('save-alias', { entity_id: entityId, value: value.value, alias_status: st.value,
+            from_year: fy.value === '' ? null : Number(fy.value), to_year: ty.value === '' ? null : Number(ty.value),
+            meaning: meaning.value || null, era_id: era.value || null });
+          closeModal(); toast('Nom enregistré'); renderFiche(); refreshStats();
+        } catch (e) { toast(e.message, true); }
+      } }))));
+}
+
+function readingForm(questionId) {
+  const text = h('textarea', { placeholder: 'Une lecture possible du mystère' });
+  const source = makePicker(null, null, 'Source (facultatif)');
+  const ordinal = h('input', { type: 'number', placeholder: '1' });
+  openModal(h('div', {},
+    h('h2', { text: 'Nouvelle lecture' }),
+    field('Texte', text),
+    h('div', { class: 'grid2' }, field('Ordre', ordinal), field('Source', source.element)),
+    h('div', { class: 'actions' },
+      h('button', { class: 'ghost', onclick: closeModal, text: 'Annuler' }),
+      h('button', { class: 'primary', text: 'Enregistrer', onclick: async () => {
+        try {
+          await KG.post('save-reading', { question_id: questionId, text: text.value, source_id: source.get(), ordinal: Number(ordinal.value) || 0 });
+          closeModal(); toast('Lecture enregistrée'); renderFiche();
+        } catch (e) { toast(e.message, true); }
+      } }))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CHRONOLOGIE
+// ═══════════════════════════════════════════════════════════════════════════════
+async function renderChronologie() {
+  const view = $('#view'); view.innerHTML = '';
+  const c = S.catalog;
+  const ftype = selectFrom([''].concat(c.factTypes), '');
+  const from = h('input', { type: 'number', placeholder: 'de (année)', style: 'width:120px' });
+  const to = h('input', { type: 'number', placeholder: 'à (année)', style: 'width:120px' });
+  const out = h('div', {});
+  const run = async () => {
+    const { facts } = await guard(() => KG.get('chronologie', { fact_type: ftype.value, from_year: from.value, to_year: to.value }));
+    out.innerHTML = '';
+    if (!facts.length) { out.append(h('div', { class: 'empty', text: 'Aucun fait.' })); return; }
+    out.append(h('p', { class: 'faint', text: facts.length + ' faits, triés par date puis ordre.' }));
+    facts.forEach(f => out.append(item(f.dateLabel,
+      [h('strong', { text: f.fact_type }), ' ', h('a', { onclick: () => selectEntity(f.subject_id), text: f.subjectName }),
+       f.objectName ? h('span', { class: 'muted', text: ' @ ' + f.objectName }) : null,
+       f.status !== 'canon' ? h('span', { class: 'badge st-' + f.status, text: ' ' + f.status }) : null,
+       f.sourceName ? h('span', { class: 'faint', text: ' · ' + f.sourceName }) : null])));
+  };
+  view.append(h('div', { class: 'section' },
+    h('h3', {}, h('span', { text: 'Chronologie' })),
+    h('div', { class: 'row', style: 'margin-bottom:14px; flex-wrap:wrap' },
+      ftype, from, to, h('button', { onclick: run, text: 'Filtrer' })),
+    out));
+  run();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// DIRIGEANTS
+// ═══════════════════════════════════════════════════════════════════════════════
+async function renderDirigeants() {
+  const view = $('#view'); view.innerHTML = '';
+  const picker = makePicker(null, null, 'Choisir une entité politique…');
+  const out = h('div', {});
+  const run = async () => {
+    const id = picker.get(); if (!id) return toast('Choisis une entité politique', true);
+    const { dirigeants } = await guard(() => KG.get('dirigeants', { id }));
+    out.innerHTML = '';
+    out.append(h('h2', { text: dirigeants.polityName || id, style: 'margin:6px 0' }));
+    if (!dirigeants.regnes.length) { out.append(h('div', { class: 'empty', text: 'Aucun règne enregistré. Ajoute des faits « regne » avec cette entité comme objet.' })); return; }
+    dirigeants.regnes.forEach((r, i) => out.append(item(r.dateLabel,
+      [h('span', { class: 'faint', text: (i + 1) + '. ' }), h('a', { onclick: () => selectEntity(r.rulerId), text: r.rulerName })])));
+    if (dirigeants.anomalies.length) {
+      out.append(h('h3', { text: 'Anomalies de succession', style: 'color:var(--warn); margin-top:18px' }));
+      dirigeants.anomalies.forEach(a => out.append(h('div', { class: 'issue avert' }, h('div', { class: 'k', text: a.type }), h('div', { text: a.detail }))));
+    }
+  };
+  view.append(h('div', { class: 'section' },
+    h('h3', {}, h('span', { text: 'Liste de dirigeants (calculée depuis les faits « regne »)' })),
+    h('div', { class: 'row', style: 'margin-bottom:14px' }, h('div', { class: 'grow' }, picker.element), h('button', { onclick: run, text: 'Afficher' })),
+    out));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// COHÉRENCE
+// ═══════════════════════════════════════════════════════════════════════════════
+async function renderCoherence() {
+  const view = $('#view'); view.innerHTML = '';
+  view.append(h('div', { class: 'empty', text: 'Analyse en cours…' }));
+  const { report } = await guard(() => KG.get('coherence'));
+  view.innerHTML = '';
+  const c = report.counts;
+  view.append(h('div', { class: 'section' },
+    h('h3', {}, h('span', { text: 'Rapport de cohérence' })),
+    h('div', { class: 'row', style: 'gap:14px; margin-bottom:16px' },
+      h('span', { class: 'badge', style: 'color:var(--err)', text: c.erreur + ' erreurs' }),
+      h('span', { class: 'badge', style: 'color:var(--warn)', text: c.avert + ' avertissements' }),
+      h('span', { class: 'badge', style: 'color:var(--accent)', text: c.info + ' infos' }))));
+  if (!report.issues.length) { view.append(h('div', { class: 'empty', text: '✓ Aucune contradiction détectée. Le graphe est cohérent.' })); return; }
+  const order = { erreur: 0, avert: 1, info: 2 };
+  report.issues.sort((a, b) => order[a.severity] - order[b.severity]);
+  report.issues.forEach(i => view.append(h('div', { class: 'issue ' + i.severity },
+    h('div', { class: 'k', text: i.severity + ' · ' + i.kind }),
+    h('div', {}, h('span', { text: i.message + ' ' }), i.refId ? h('a', { onclick: () => selectEntity(i.refId), text: '↗' }) : null))));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BOOT
+// ═══════════════════════════════════════════════════════════════════════════════
+$('#search').addEventListener('input', (e) => { S.search = e.target.value.trim(); clearTimeout(S._st); S._st = setTimeout(loadEntities, 200); });
+$('#btnNew').addEventListener('click', () => entityForm(null));
+$('#btnCoherence').addEventListener('click', () => { S.tab = 'coherence'; document.querySelectorAll('#tabs .tab').forEach(t => t.classList.toggle('active', t.dataset.tab === 'coherence')); renderView(); });
+$('#btnLogout').addEventListener('click', () => { sessionStorage.removeItem('kgpw'); KG.pw = ''; location.reload(); });
+
+async function boot() {
+  S.catalog = (await guard(() => KG.get('catalog')));
+  renderTypeFilter();
+  await Promise.all([loadEntities(), refreshStats()]);
+  renderView();
+}
+
+(async function init() {
+  if (!KG.pw) return askPassword();
+  try { await KG.get('stats'); boot(); }
+  catch { askPassword(); }
+})();

--- a/lib/kg-core.js
+++ b/lib/kg-core.js
@@ -1,0 +1,927 @@
+'use strict';
+/*
+ * lib/kg-core.js — Le cœur du graphe de connaissances canonique d'Hybélior.
+ *
+ * PRINCIPE : le site est la source de vérité unique. Chaque information
+ * (personne, empire, ville, événement, concept, religion, espèce, objet…)
+ * n'existe qu'à un seul endroit — une ligne de ce graphe — et est PROJETÉE
+ * partout ailleurs (fiche, chronologie, arbre, liste de dirigeants…).
+ *
+ * Ce module est BACKEND-AGNOSTIQUE. Il reçoit une fonction d'exécution :
+ *
+ *     exec(sql, args) -> Promise<{ rows: Object[], lastInsertRowid?: number }>
+ *
+ * où `args` est un tableau de valeurs JS simples (string | number | null).
+ * Le MÊME SQL tourne en production (Turso / libSQL via HTTP) et en
+ * développement (node:sqlite). Toute la logique — validation, cohérence,
+ * projections — est écrite ici UNE seule fois. Les adaptateurs ne font que
+ * du stockage.
+ *
+ * Aucune dépendance externe. CommonJS (require) pour être chargeable aussi
+ * bien par les fonctions serverless Vercel que par server.js.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. CATALOGUES — l'ontologie fermée du monde
+// ─────────────────────────────────────────────────────────────────────────
+// Fermer les catalogues est ce qui empêche une faute de frappe de créer un
+// type d'entité ou une relation « fantôme ». On étend le monde en étendant
+// ces listes, jamais à la volée.
+
+const ENTITY_TYPES = [
+  'personne',        // tout individu nommé
+  'lignee',          // lignée / dynastie
+  'lieu',            // entité géographique (échelle dans data)
+  'entite-politique',// empire, royaume, cité-État (distinct du sol)
+  'evenement',       // fait daté d'importance (peut aussi être un kg_fact)
+  'concept',         // notion cosmologique ou abstraite
+  'religion',        // culte, ordre, foi
+  'espece',          // peuple, race, ordre d'êtres
+  'objet',           // artefact nommé
+  'terme',           // entrée de lexique / glossaire
+  'source',          // œuvre canonique — fait AUTORITÉ (voir rang)
+  'question',        // mystère protégé — première classe (voir readings)
+  'oeuvre',          // roman / récit comme objet éditorial
+  'ere',             // ère chronologique (borne d'événements)
+];
+
+// Échelles pour les lieux, du plus grand au plus petit.
+const LIEU_SCALES = ['monde', 'continent', 'region', 'nation', 'cite', 'ville', 'bourg', 'ruine', 'lieu-dit'];
+
+// Rang canonique d'une source (hiérarchie d'autorité).
+const SOURCE_RANKS = ['texte-publie', 'bible', 'chronique-interne', 'note-travail'];
+
+const FACT_TYPES = [
+  'naissance', 'mort',
+  'regne', 'succession', 'couronnement', 'abdication',
+  'fondation', 'chute',
+  'frontiere',           // tracé daté (le polygone vit dans country_borders)
+  'bataille', 'traite',
+  'apparition', 'disparition',
+  'evenement', 'autre',
+];
+
+// Relations typées et dirigées. Le catalogue est fermé.
+const REL_TYPES = [
+  // filiation
+  'parent-de', 'conjoint-de', 'fratrie-de', 'descend-de',
+  // politique
+  'gouverne', 'capitale-de', 'vassal-de', 'allie-de', 'en-guerre-avec', 'succede-a',
+  // spatial
+  'situe-dans', 'frontiere-avec',
+  // cosmologique / religieux
+  'incarne', 'pratique', 'venere', 'fonde', 'schisme-de',
+  // appartenance / textuel
+  'membre-de', 'apparait-dans', 'source-de', 'mentionne', 'lie-a',
+  // désambiguïsation
+  'a-ne-pas-confondre-avec',
+];
+
+// Étiquette inverse d'une relation, pour l'affichage du côté récepteur.
+// (On ne stocke JAMAIS l'arête inverse — elle est calculée à la projection.)
+const REL_INVERSE = {
+  'parent-de': 'enfant de',
+  'conjoint-de': 'conjoint de',
+  'fratrie-de': 'de la fratrie de',
+  'descend-de': 'ancêtre de',
+  'gouverne': 'gouverné par',
+  'capitale-de': 'a pour capitale',
+  'vassal-de': 'suzerain de',
+  'allie-de': 'allié de',
+  'en-guerre-avec': 'en guerre avec',
+  'succede-a': 'précède',
+  'situe-dans': 'contient',
+  'frontiere-avec': 'frontalier de',
+  'incarne': 'incarné par',
+  'pratique': 'pratiqué par',
+  'venere': 'vénéré par',
+  'fonde': 'fondé par',
+  'schisme-de': 'a pour schisme',
+  'membre-de': 'compte pour membre',
+  'apparait-dans': 'met en scène',
+  'source-de': 'attesté par',
+  'mentionne': 'mentionné par',
+  'lie-a': 'lié à',
+  'a-ne-pas-confondre-avec': 'à ne pas confondre avec',
+};
+
+// Statut épistémique — le graphe représente ce qu'on sait ET à quel degré.
+const STATUSES = ['canon', 'lecture-disputee', 'rumeur', 'retconne'];
+
+// Horizon de divulgation (site privé, mais utile pour trier établi/spéculatif).
+const DISCLOSURES = ['public', 't1', 't2', 't3', 't4', 'interne'];
+
+// Précision d'une date — jamais de fausse exactitude.
+const PRECISIONS = ['exact', 'annee', 'decennie', 'siecle', 'estimation'];
+
+// Statut d'un alias (nom daté).
+const ALIAS_STATUSES = ['visible', 'predecessor', 'vanished', 'variante', 'desambig'];
+
+const ID_PREFIX = {
+  personne: 'per', lignee: 'lig', lieu: 'lie', 'entite-politique': 'pol',
+  evenement: 'evt', concept: 'con', religion: 'rel', espece: 'esp',
+  objet: 'obj', terme: 'ter', source: 'src', question: 'que',
+  oeuvre: 'oeu', ere: 'ere',
+};
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. SCHÉMA — le DDL, exécuté instruction par instruction (uniforme aux 2 backends)
+// ─────────────────────────────────────────────────────────────────────────
+
+const SCHEMA_STATEMENTS = [
+  `CREATE TABLE IF NOT EXISTS kg_entities (
+     id         TEXT PRIMARY KEY,
+     type       TEXT NOT NULL,
+     name       TEXT NOT NULL,
+     slug       TEXT,
+     summary    TEXT,
+     body       TEXT,
+     data       TEXT,
+     status     TEXT NOT NULL DEFAULT 'canon',
+     disclosure TEXT NOT NULL DEFAULT 'interne',
+     created_at TEXT,
+     updated_at TEXT
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_entities_type ON kg_entities(type)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_entities_name ON kg_entities(name)`,
+
+  `CREATE TABLE IF NOT EXISTS kg_aliases (
+     id           INTEGER PRIMARY KEY AUTOINCREMENT,
+     entity_id    TEXT NOT NULL,
+     value        TEXT NOT NULL,
+     alias_status TEXT NOT NULL DEFAULT 'visible',
+     era_id       TEXT,
+     from_year    INTEGER,
+     to_year      INTEGER,
+     meaning      TEXT,
+     UNIQUE(entity_id, value, era_id)
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_aliases_entity ON kg_aliases(entity_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_aliases_value ON kg_aliases(value)`,
+
+  `CREATE TABLE IF NOT EXISTS kg_facts (
+     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+     fact_type       TEXT NOT NULL,
+     subject_id      TEXT NOT NULL,
+     object_id       TEXT,
+     start_year      INTEGER,
+     start_precision TEXT DEFAULT 'annee',
+     start_circa     INTEGER DEFAULT 0,
+     end_year        INTEGER,
+     end_precision   TEXT,
+     end_circa       INTEGER DEFAULT 0,
+     era_id          TEXT,
+     seq             INTEGER DEFAULT 0,
+     label           TEXT,
+     detail          TEXT,
+     data            TEXT,
+     source_id       TEXT,
+     status          TEXT NOT NULL DEFAULT 'canon',
+     disclosure      TEXT NOT NULL DEFAULT 'interne',
+     created_at      TEXT,
+     updated_at      TEXT
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_facts_subject ON kg_facts(subject_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_facts_object ON kg_facts(object_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_facts_year ON kg_facts(start_year)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_facts_type ON kg_facts(fact_type)`,
+
+  `CREATE TABLE IF NOT EXISTS kg_relations (
+     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+     rel_type   TEXT NOT NULL,
+     from_id    TEXT NOT NULL,
+     to_id      TEXT NOT NULL,
+     start_year INTEGER,
+     end_year   INTEGER,
+     label      TEXT,
+     data       TEXT,
+     source_id  TEXT,
+     status     TEXT NOT NULL DEFAULT 'canon',
+     UNIQUE(rel_type, from_id, to_id, start_year)
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_relations_from ON kg_relations(from_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_relations_to ON kg_relations(to_id)`,
+
+  `CREATE TABLE IF NOT EXISTS kg_readings (
+     id             INTEGER PRIMARY KEY AUTOINCREMENT,
+     question_id    TEXT NOT NULL,
+     text           TEXT NOT NULL,
+     source_id      TEXT,
+     reading_status TEXT DEFAULT 'lecture-sourcee',
+     ordinal        INTEGER DEFAULT 0
+   )`,
+  `CREATE INDEX IF NOT EXISTS idx_kg_readings_q ON kg_readings(question_id)`,
+
+  `CREATE TABLE IF NOT EXISTS kg_audit (
+     id         INTEGER PRIMARY KEY AUTOINCREMENT,
+     ref_id     TEXT,
+     kind       TEXT,
+     op         TEXT,
+     before     TEXT,
+     after      TEXT,
+     changed_at TEXT
+   )`,
+];
+
+async function initSchema(exec) {
+  for (const sql of SCHEMA_STATEMENTS) {
+    await exec(sql, []);
+  }
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. UTILITAIRES
+// ─────────────────────────────────────────────────────────────────────────
+
+async function q(exec, sql, args) {
+  const r = await exec(sql, args || []);
+  return (r && r.rows) || [];
+}
+
+function nowIso() {
+  // Passé par l'appelant via param quand disponible ; sinon ISO courant.
+  return new Date().toISOString();
+}
+
+function num(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isNaN(n) ? null : n;
+}
+
+function str(v) {
+  return v === null || v === undefined ? null : String(v);
+}
+
+function jsonOrNull(v) {
+  if (v === null || v === undefined || v === '') return null;
+  if (typeof v === 'string') return v;
+  try { return JSON.stringify(v); } catch { return null; }
+}
+
+function parseJson(v) {
+  if (v === null || v === undefined || v === '') return null;
+  try { return typeof v === 'string' ? JSON.parse(v) : v; } catch { return null; }
+}
+
+class KGError extends Error {
+  constructor(message, code) { super(message); this.code = code || 'validation'; }
+}
+
+// Génère le prochain id stable et opaque pour un type (per-0001, pol-0042…).
+async function nextId(exec, type) {
+  const prefix = ID_PREFIX[type];
+  if (!prefix) throw new KGError(`Type d'entité inconnu : ${type}`);
+  const rows = await q(exec,
+    `SELECT id FROM kg_entities WHERE id LIKE ? ORDER BY id`, [prefix + '-%']);
+  let max = 0;
+  for (const r of rows) {
+    const m = /-(\d+)$/.exec(r.id);
+    if (m) { const n = parseInt(m[1], 10); if (n > max) max = n; }
+  }
+  return `${prefix}-${String(max + 1).padStart(4, '0')}`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. FORMATAGE DES DATES — le double calendrier et la précision variable
+// ─────────────────────────────────────────────────────────────────────────
+// L'axe canonique interne est l'An 0 = l'Arrachement (av.A / ap.A). La date
+// n'est jamais une chaîne : elle porte sa propre incertitude et ne ment
+// jamais par excès de confiance.
+
+function formatYear(year, precision, circa) {
+  if (year === null || year === undefined) return '—';
+  const y = Number(year);
+  const approx = circa ? '~' : (precision === 'estimation' ? '≈' : '');
+  if (y === 0) return `${approx}An 0 (l'Arrachement)`;
+  const abs = Math.abs(y);
+  const suffix = y < 0 ? 'av.A' : 'ap.A';
+  if (precision === 'siecle') {
+    const siecle = Math.floor(abs / 100) + (abs % 100 === 0 ? 0 : 1);
+    return `${approx}${siecle}ᵉ s. ${suffix}`;
+  }
+  return `${approx}${abs.toLocaleString('fr-FR')} ${suffix}`;
+}
+
+function formatRange(f) {
+  const start = formatYear(f.start_year, f.start_precision, f.start_circa);
+  if (f.end_year === null || f.end_year === undefined) return start;
+  const end = formatYear(f.end_year, f.end_precision, f.end_circa);
+  return `${start} → ${end}`;
+}
+
+// Clé de tri temporel : (année de début, seq). Les dates inconnues finissent
+// en tête (négatif infini) pour ne pas polluer le milieu de la frise.
+function sortKey(f) {
+  const y = f.start_year === null || f.start_year === undefined ? -Infinity : Number(f.start_year);
+  const s = f.seq === null || f.seq === undefined ? 0 : Number(f.seq);
+  return [y, s];
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. ENTITÉS — CRUD
+// ─────────────────────────────────────────────────────────────────────────
+
+function validateEntity(e) {
+  if (!e || typeof e !== 'object') throw new KGError('Entité manquante');
+  if (!ENTITY_TYPES.includes(e.type)) throw new KGError(`Type inconnu : ${e.type}`);
+  if (!e.name || !String(e.name).trim()) throw new KGError('Le nom est obligatoire');
+  if (e.status && !STATUSES.includes(e.status)) throw new KGError(`Statut inconnu : ${e.status}`);
+  if (e.disclosure && !DISCLOSURES.includes(e.disclosure)) throw new KGError(`Divulgation inconnue : ${e.disclosure}`);
+}
+
+async function listEntities(exec, opts) {
+  opts = opts || {};
+  const where = [];
+  const args = [];
+  if (opts.type) { where.push('type = ?'); args.push(opts.type); }
+  if (opts.search) {
+    where.push('(name LIKE ? OR id IN (SELECT entity_id FROM kg_aliases WHERE value LIKE ?))');
+    args.push('%' + opts.search + '%', '%' + opts.search + '%');
+  }
+  const sql = `SELECT id, type, name, summary, status, disclosure
+               FROM kg_entities
+               ${where.length ? 'WHERE ' + where.join(' AND ') : ''}
+               ORDER BY name COLLATE NOCASE`;
+  return q(exec, sql, args);
+}
+
+async function getEntity(exec, id) {
+  const rows = await q(exec, `SELECT * FROM kg_entities WHERE id = ?`, [id]);
+  if (!rows.length) return null;
+  const e = rows[0];
+  e.data = parseJson(e.data);
+  return e;
+}
+
+async function upsertEntity(exec, input, when) {
+  validateEntity(input);
+  const ts = when || nowIso();
+  let id = input.id;
+  const existing = id ? await getEntity(exec, id) : null;
+  if (!id) id = await nextId(exec, input.type);
+
+  await exec(
+    `INSERT INTO kg_entities (id, type, name, slug, summary, body, data, status, disclosure, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       type=excluded.type, name=excluded.name, slug=excluded.slug,
+       summary=excluded.summary, body=excluded.body, data=excluded.data,
+       status=excluded.status, disclosure=excluded.disclosure,
+       updated_at=excluded.updated_at`,
+    [
+      id, input.type, String(input.name).trim(), str(input.slug),
+      str(input.summary), str(input.body), jsonOrNull(input.data),
+      input.status || 'canon', input.disclosure || 'interne',
+      existing ? existing.created_at : ts, ts,
+    ]
+  );
+  await audit(exec, id, 'entity', existing ? 'update' : 'create', existing, { id, ...input }, ts);
+  return getEntity(exec, id);
+}
+
+async function deleteEntity(exec, id, when) {
+  const existing = await getEntity(exec, id);
+  if (!existing) throw new KGError('Entité introuvable', 'not-found');
+  // Intégrité : refuser la suppression si l'entité est encore référencée.
+  const refs = await q(exec,
+    `SELECT 'fait' AS k FROM kg_facts WHERE subject_id=? OR object_id=? OR source_id=?
+     UNION ALL SELECT 'relation' FROM kg_relations WHERE from_id=? OR to_id=? OR source_id=?
+     UNION ALL SELECT 'lecture' FROM kg_readings WHERE question_id=? OR source_id=?`,
+    [id, id, id, id, id, id, id, id]);
+  if (refs.length) {
+    throw new KGError(`Suppression refusée : encore référencée par ${refs.length} élément(s). Détache-les d'abord.`, 'referenced');
+  }
+  await exec(`DELETE FROM kg_aliases WHERE entity_id=?`, [id]);
+  await exec(`DELETE FROM kg_entities WHERE id=?`, [id]);
+  await audit(exec, id, 'entity', 'delete', existing, null, when || nowIso());
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 6. ALIAS — les noms sont des données datées (généralise timeline_names)
+// ─────────────────────────────────────────────────────────────────────────
+
+async function getAliases(exec, entityId) {
+  return q(exec,
+    `SELECT id, entity_id, value, alias_status, era_id, from_year, to_year, meaning
+     FROM kg_aliases WHERE entity_id=? ORDER BY from_year IS NULL DESC, from_year`, [entityId]);
+}
+
+async function upsertAlias(exec, a) {
+  if (!a.entity_id) throw new KGError('entity_id manquant');
+  if (!a.value || !String(a.value).trim()) throw new KGError('Valeur du nom manquante');
+  if (a.alias_status && !ALIAS_STATUSES.includes(a.alias_status)) {
+    throw new KGError(`Statut d'alias inconnu : ${a.alias_status}`);
+  }
+  const owner = await getEntity(exec, a.entity_id);
+  if (!owner) throw new KGError(`Entité inexistante : ${a.entity_id}`, 'ref');
+  await exec(
+    `INSERT INTO kg_aliases (entity_id, value, alias_status, era_id, from_year, to_year, meaning)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(entity_id, value, era_id) DO UPDATE SET
+       alias_status=excluded.alias_status, from_year=excluded.from_year,
+       to_year=excluded.to_year, meaning=excluded.meaning`,
+    [a.entity_id, String(a.value).trim(), a.alias_status || 'visible',
+     str(a.era_id), num(a.from_year), num(a.to_year), str(a.meaning)]
+  );
+  return { ok: true };
+}
+
+async function deleteAlias(exec, id) {
+  await exec(`DELETE FROM kg_aliases WHERE id=?`, [num(id)]);
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 7. FAITS DATÉS — le cœur événementiel (chronologie, règnes, vies…)
+// ─────────────────────────────────────────────────────────────────────────
+
+async function validateFact(exec, f) {
+  if (!FACT_TYPES.includes(f.fact_type)) throw new KGError(`Type de fait inconnu : ${f.fact_type}`);
+  if (!f.subject_id) throw new KGError('Sujet manquant');
+  const subj = await getEntity(exec, f.subject_id);
+  if (!subj) throw new KGError(`Sujet inexistant : ${f.subject_id}`, 'ref');
+  if (f.object_id) {
+    const obj = await getEntity(exec, f.object_id);
+    if (!obj) throw new KGError(`Objet inexistant : ${f.object_id}`, 'ref');
+  }
+  if (f.source_id) {
+    const src = await getEntity(exec, f.source_id);
+    if (!src) throw new KGError(`Source inexistante : ${f.source_id}`, 'ref');
+    if (src.type !== 'source') throw new KGError(`La source doit être de type « source » : ${f.source_id}`);
+  }
+  if (f.start_precision && !PRECISIONS.includes(f.start_precision)) throw new KGError(`Précision inconnue : ${f.start_precision}`);
+  if (f.end_precision && !PRECISIONS.includes(f.end_precision)) throw new KGError(`Précision inconnue : ${f.end_precision}`);
+  if (f.status && !STATUSES.includes(f.status)) throw new KGError(`Statut inconnu : ${f.status}`);
+  // Cohérence intra-fait : la fin ne précède pas le début.
+  const s = num(f.start_year), e = num(f.end_year);
+  if (s !== null && e !== null && e < s) {
+    throw new KGError(`Incohérence temporelle : la fin (${e}) précède le début (${s}).`);
+  }
+  // Un fait « canon » doit citer une source (pas de canon anonyme).
+  if ((f.status || 'canon') === 'canon' && !f.source_id) {
+    // Avertissement non bloquant : renvoyé pour affichage, pas une erreur dure.
+    return { warning: 'Fait canon sans source — provenance recommandée.' };
+  }
+  return {};
+}
+
+async function getFact(exec, id) {
+  const rows = await q(exec, `SELECT * FROM kg_facts WHERE id=?`, [num(id)]);
+  if (!rows.length) return null;
+  rows[0].data = parseJson(rows[0].data);
+  return rows[0];
+}
+
+async function upsertFact(exec, f, when) {
+  const check = await validateFact(exec, f);
+  const ts = when || nowIso();
+  const cols = [
+    f.fact_type, f.subject_id, str(f.object_id),
+    num(f.start_year), f.start_precision || 'annee', f.start_circa ? 1 : 0,
+    num(f.end_year), str(f.end_precision), f.end_circa ? 1 : 0,
+    str(f.era_id), num(f.seq) || 0, str(f.label), str(f.detail),
+    jsonOrNull(f.data), str(f.source_id), f.status || 'canon',
+    f.disclosure || 'interne',
+  ];
+  if (f.id) {
+    await exec(
+      `UPDATE kg_facts SET fact_type=?, subject_id=?, object_id=?, start_year=?,
+        start_precision=?, start_circa=?, end_year=?, end_precision=?, end_circa=?,
+        era_id=?, seq=?, label=?, detail=?, data=?, source_id=?, status=?, disclosure=?,
+        updated_at=? WHERE id=?`,
+      [...cols, ts, num(f.id)]
+    );
+    await audit(exec, f.subject_id, 'fact', 'update', { id: f.id }, f, ts);
+    return getFact(exec, f.id);
+  }
+  const rows = await q(exec,
+    `INSERT INTO kg_facts
+       (fact_type, subject_id, object_id, start_year, start_precision, start_circa,
+        end_year, end_precision, end_circa, era_id, seq, label, detail, data,
+        source_id, status, disclosure, created_at, updated_at)
+     VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) RETURNING id`,
+    [...cols, ts, ts]
+  );
+  const id = rows.length ? rows[0].id : null;
+  await audit(exec, f.subject_id, 'fact', 'create', null, f, ts);
+  const saved = await getFact(exec, id);
+  if (check.warning) saved._warning = check.warning;
+  return saved;
+}
+
+async function deleteFact(exec, id, when) {
+  const f = await getFact(exec, id);
+  await exec(`DELETE FROM kg_facts WHERE id=?`, [num(id)]);
+  if (f) await audit(exec, f.subject_id, 'fact', 'delete', f, null, when || nowIso());
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 8. RELATIONS — typées, dirigées, saisies une seule fois
+// ─────────────────────────────────────────────────────────────────────────
+
+async function validateRelation(exec, r) {
+  if (!REL_TYPES.includes(r.rel_type)) throw new KGError(`Relation inconnue : ${r.rel_type}`);
+  if (!r.from_id || !r.to_id) throw new KGError('from_id et to_id sont obligatoires');
+  if (r.from_id === r.to_id) throw new KGError('Une entité ne peut pas être en relation avec elle-même');
+  const a = await getEntity(exec, r.from_id);
+  if (!a) throw new KGError(`Entité source inexistante : ${r.from_id}`, 'ref');
+  const b = await getEntity(exec, r.to_id);
+  if (!b) throw new KGError(`Entité cible inexistante : ${r.to_id}`, 'ref');
+  if (r.source_id) {
+    const src = await getEntity(exec, r.source_id);
+    if (!src) throw new KGError(`Source inexistante : ${r.source_id}`, 'ref');
+  }
+  if (r.status && !STATUSES.includes(r.status)) throw new KGError(`Statut inconnu : ${r.status}`);
+}
+
+async function upsertRelation(exec, r) {
+  await validateRelation(exec, r);
+  await exec(
+    `INSERT INTO kg_relations (rel_type, from_id, to_id, start_year, end_year, label, data, source_id, status)
+     VALUES (?,?,?,?,?,?,?,?,?)
+     ON CONFLICT(rel_type, from_id, to_id, start_year) DO UPDATE SET
+       end_year=excluded.end_year, label=excluded.label, data=excluded.data,
+       source_id=excluded.source_id, status=excluded.status`,
+    [r.rel_type, r.from_id, r.to_id, num(r.start_year), num(r.end_year),
+     str(r.label), jsonOrNull(r.data), str(r.source_id), r.status || 'canon']
+  );
+  return { ok: true };
+}
+
+async function deleteRelation(exec, id) {
+  await exec(`DELETE FROM kg_relations WHERE id=?`, [num(id)]);
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 9. LECTURES — les lectures concurrentes d'un mystère protégé
+// ─────────────────────────────────────────────────────────────────────────
+
+async function getReadings(exec, questionId) {
+  return q(exec,
+    `SELECT id, question_id, text, source_id, reading_status, ordinal
+     FROM kg_readings WHERE question_id=? ORDER BY ordinal, id`, [questionId]);
+}
+
+async function upsertReading(exec, r) {
+  if (!r.question_id) throw new KGError('question_id manquant');
+  if (!r.text || !String(r.text).trim()) throw new KGError('Texte de la lecture manquant');
+  const owner = await getEntity(exec, r.question_id);
+  if (!owner) throw new KGError(`Question inexistante : ${r.question_id}`, 'ref');
+  if (owner.type !== 'question') throw new KGError('Les lectures ne s\'attachent qu\'à une entité « question »');
+  if (r.id) {
+    await exec(`UPDATE kg_readings SET text=?, source_id=?, reading_status=?, ordinal=? WHERE id=?`,
+      [String(r.text).trim(), str(r.source_id), r.reading_status || 'lecture-sourcee', num(r.ordinal) || 0, num(r.id)]);
+    return { ok: true };
+  }
+  await exec(`INSERT INTO kg_readings (question_id, text, source_id, reading_status, ordinal) VALUES (?,?,?,?,?)`,
+    [r.question_id, String(r.text).trim(), str(r.source_id), r.reading_status || 'lecture-sourcee', num(r.ordinal) || 0]);
+  return { ok: true };
+}
+
+async function deleteReading(exec, id) {
+  await exec(`DELETE FROM kg_readings WHERE id=?`, [num(id)]);
+  return { ok: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 10. AUDIT — journal des changements (durabilité, retcons traçables)
+// ─────────────────────────────────────────────────────────────────────────
+
+async function audit(exec, refId, kind, op, before, after, when) {
+  try {
+    await exec(
+      `INSERT INTO kg_audit (ref_id, kind, op, before, after, changed_at) VALUES (?,?,?,?,?,?)`,
+      [str(refId), kind, op, jsonOrNull(before), jsonOrNull(after), when || nowIso()]
+    );
+  } catch { /* l'audit ne doit jamais bloquer une écriture */ }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 11. PROJECTIONS — une info écrite une fois, affichée partout
+// ─────────────────────────────────────────────────────────────────────────
+
+// Résout un ensemble d'ids en {id: {id, name, type}} en une requête.
+async function resolveNames(exec, ids) {
+  const uniq = [...new Set(ids.filter(Boolean))];
+  if (!uniq.length) return {};
+  const placeholders = uniq.map(() => '?').join(',');
+  const rows = await q(exec, `SELECT id, name, type FROM kg_entities WHERE id IN (${placeholders})`, uniq);
+  const map = {};
+  for (const r of rows) map[r.id] = r;
+  return map;
+}
+
+// LE DOSSIER (la « fiche ») : tout ce que le graphe sait d'une entité,
+// agrégé à la lecture — jamais dupliqué au stockage.
+async function getDossier(exec, id) {
+  const entity = await getEntity(exec, id);
+  if (!entity) return null;
+
+  const aliases = await getAliases(exec, id);
+
+  // Faits où l'entité est sujet OU objet.
+  const factRows = await q(exec,
+    `SELECT * FROM kg_facts WHERE subject_id=? OR object_id=?`, [id, id]);
+  // Relations où l'entité est source OU cible.
+  const relOut = await q(exec, `SELECT * FROM kg_relations WHERE from_id=?`, [id]);
+  const relIn = await q(exec, `SELECT * FROM kg_relations WHERE to_id=?`, [id]);
+  const readings = entity.type === 'question' ? await getReadings(exec, id) : [];
+
+  // Résoudre tous les noms référencés en une passe.
+  const refIds = [];
+  factRows.forEach(f => { refIds.push(f.subject_id, f.object_id, f.source_id); });
+  relOut.forEach(r => { refIds.push(r.to_id, r.source_id); });
+  relIn.forEach(r => { refIds.push(r.from_id, r.source_id); });
+  readings.forEach(r => refIds.push(r.source_id));
+  const names = await resolveNames(exec, refIds);
+  const nameOf = (rid) => (rid && names[rid] ? names[rid].name : rid) || null;
+
+  const facts = factRows
+    .map(f => ({
+      ...f,
+      data: parseJson(f.data),
+      dateLabel: formatRange(f),
+      subjectName: nameOf(f.subject_id),
+      objectName: nameOf(f.object_id),
+      sourceName: nameOf(f.source_id),
+      role: f.subject_id === id ? 'sujet' : 'objet',
+    }))
+    .sort((a, b) => {
+      const [ay, as] = sortKey(a); const [by, bs] = sortKey(b);
+      return ay - by || as - bs || a.id - b.id;
+    });
+
+  const relations = [
+    ...relOut.map(r => ({ ...r, data: parseJson(r.data), direction: 'sortante',
+      label: r.rel_type, otherId: r.to_id, otherName: nameOf(r.to_id), sourceName: nameOf(r.source_id) })),
+    ...relIn.map(r => ({ ...r, data: parseJson(r.data), direction: 'entrante',
+      label: REL_INVERSE[r.rel_type] || r.rel_type, otherId: r.from_id, otherName: nameOf(r.from_id), sourceName: nameOf(r.source_id) })),
+  ];
+
+  return {
+    entity,
+    aliases,
+    facts,
+    relations,
+    readings: readings.map(r => ({ ...r, sourceName: nameOf(r.source_id) })),
+  };
+}
+
+// LA CHRONOLOGIE : tous les faits triés par (date, seq) — projection globale.
+async function getChronologie(exec, opts) {
+  opts = opts || {};
+  const where = [];
+  const args = [];
+  if (opts.fact_type) { where.push('f.fact_type = ?'); args.push(opts.fact_type); }
+  if (opts.era_id) { where.push('f.era_id = ?'); args.push(opts.era_id); }
+  if (opts.from_year !== undefined && opts.from_year !== null && opts.from_year !== '') {
+    where.push('f.start_year >= ?'); args.push(num(opts.from_year));
+  }
+  if (opts.to_year !== undefined && opts.to_year !== null && opts.to_year !== '') {
+    where.push('f.start_year <= ?'); args.push(num(opts.to_year));
+  }
+  if (opts.status) { where.push('f.status = ?'); args.push(opts.status); }
+  const rows = await q(exec,
+    `SELECT f.* FROM kg_facts f ${where.length ? 'WHERE ' + where.join(' AND ') : ''}`, args);
+  const refIds = [];
+  rows.forEach(f => refIds.push(f.subject_id, f.object_id, f.source_id));
+  const names = await resolveNames(exec, refIds);
+  const nameOf = (rid) => (rid && names[rid] ? names[rid].name : rid) || null;
+  return rows
+    .map(f => ({
+      ...f, data: parseJson(f.data),
+      dateLabel: formatRange(f),
+      subjectName: nameOf(f.subject_id),
+      objectName: nameOf(f.object_id),
+      sourceName: nameOf(f.source_id),
+    }))
+    .sort((a, b) => {
+      const [ay, as] = sortKey(a); const [by, bs] = sortKey(b);
+      return ay - by || as - bs || a.id - b.id;
+    });
+}
+
+// LA LISTE DE DIRIGEANTS : calculée depuis les faits « regne » d'une entité
+// politique — jamais maintenue à la main. Vérifie trous et chevauchements.
+async function getDirigeants(exec, polityId) {
+  const rows = await q(exec,
+    `SELECT * FROM kg_facts WHERE fact_type='regne' AND object_id=?`, [polityId]);
+  const names = await resolveNames(exec, rows.map(r => r.subject_id).concat([polityId]));
+  const nameOf = (rid) => (rid && names[rid] ? names[rid].name : rid) || null;
+  const regnes = rows
+    .map(f => ({
+      factId: f.id, rulerId: f.subject_id, rulerName: nameOf(f.subject_id),
+      start_year: num(f.start_year), end_year: num(f.end_year),
+      dateLabel: formatRange(f), seq: num(f.seq) || 0,
+    }))
+    .sort((a, b) => (a.start_year ?? -Infinity) - (b.start_year ?? -Infinity) || a.seq - b.seq || a.factId - b.factId);
+
+  // Anomalies de continuité (chevauchement / trou).
+  const anomalies = [];
+  for (let i = 1; i < regnes.length; i++) {
+    const prev = regnes[i - 1], cur = regnes[i];
+    if (prev.end_year !== null && cur.start_year !== null) {
+      if (cur.start_year < prev.end_year) {
+        anomalies.push({ type: 'chevauchement', between: [prev.rulerName, cur.rulerName],
+          detail: `${cur.rulerName} commence (${cur.start_year}) avant la fin de ${prev.rulerName} (${prev.end_year}).` });
+      } else if (cur.start_year - prev.end_year > 1) {
+        anomalies.push({ type: 'interregne', between: [prev.rulerName, cur.rulerName],
+          detail: `Trou de ${cur.start_year - prev.end_year} ans entre ${prev.rulerName} et ${cur.rulerName}.` });
+      }
+    }
+  }
+  return { polityId, polityName: nameOf(polityId), regnes, anomalies };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 12. COHÉRENCE — le filet de sécurité rendu visible
+// ─────────────────────────────────────────────────────────────────────────
+// Scanne tout le graphe et rapporte les violations. C'est le sens
+// opérationnel de « aucune contradiction ne peut apparaître ».
+
+async function getConsistencyReport(exec) {
+  const issues = [];
+  const add = (severity, kind, message, refId) => issues.push({ severity, kind, message, refId });
+
+  const entities = await q(exec, `SELECT id, type, name, data FROM kg_entities`);
+  const idSet = new Set(entities.map(e => e.id));
+  const byId = {}; entities.forEach(e => { byId[e.id] = e; });
+  const nameOf = (id) => (byId[id] ? byId[id].name : id);
+
+  // 12.1 Intégrité référentielle — aucun lien vers le vide.
+  const facts = await q(exec, `SELECT * FROM kg_facts`);
+  for (const f of facts) {
+    if (!idSet.has(f.subject_id)) add('erreur', 'ref', `Fait #${f.id} : sujet inexistant (${f.subject_id}).`, f.subject_id);
+    if (f.object_id && !idSet.has(f.object_id)) add('erreur', 'ref', `Fait #${f.id} : objet inexistant (${f.object_id}).`, f.object_id);
+    if (f.source_id && !idSet.has(f.source_id)) add('erreur', 'ref', `Fait #${f.id} : source inexistante (${f.source_id}).`, f.source_id);
+    if (num(f.end_year) !== null && num(f.start_year) !== null && num(f.end_year) < num(f.start_year)) {
+      add('erreur', 'temps', `Fait #${f.id} (${f.fact_type}) : fin ${f.end_year} avant début ${f.start_year}.`, f.subject_id);
+    }
+    if ((f.status || 'canon') === 'canon' && !f.source_id) {
+      add('info', 'provenance', `Fait #${f.id} (${f.fact_type} sur ${nameOf(f.subject_id)}) : canon sans source.`, f.subject_id);
+    }
+  }
+
+  const rels = await q(exec, `SELECT * FROM kg_relations`);
+  for (const r of rels) {
+    if (!idSet.has(r.from_id)) add('erreur', 'ref', `Relation #${r.id} : source inexistante (${r.from_id}).`, r.from_id);
+    if (!idSet.has(r.to_id)) add('erreur', 'ref', `Relation #${r.id} : cible inexistante (${r.to_id}).`, r.to_id);
+  }
+  const aliases = await q(exec, `SELECT * FROM kg_aliases`);
+  for (const a of aliases) {
+    if (!idSet.has(a.entity_id)) add('erreur', 'ref', `Alias « ${a.value} » : entité inexistante (${a.entity_id}).`, a.entity_id);
+  }
+  const readings = await q(exec, `SELECT * FROM kg_readings`);
+  for (const rd of readings) {
+    if (!idSet.has(rd.question_id)) add('erreur', 'ref', `Lecture #${rd.id} : question inexistante (${rd.question_id}).`, rd.question_id);
+  }
+
+  // 12.2 Cohérence de vie — naissance avant mort ; règne dans la vie.
+  const bySubject = {};
+  for (const f of facts) {
+    (bySubject[f.subject_id] = bySubject[f.subject_id] || []).push(f);
+  }
+  for (const [sid, fs] of Object.entries(bySubject)) {
+    const naissance = fs.find(f => f.fact_type === 'naissance');
+    const mort = fs.find(f => f.fact_type === 'mort');
+    if (naissance && mort && num(naissance.start_year) !== null && num(mort.start_year) !== null
+        && num(mort.start_year) < num(naissance.start_year)) {
+      add('erreur', 'temps', `${nameOf(sid)} : mort (${mort.start_year}) avant naissance (${naissance.start_year}).`, sid);
+    }
+    for (const r of fs.filter(f => f.fact_type === 'regne')) {
+      if (naissance && num(r.start_year) !== null && num(naissance.start_year) !== null
+          && num(r.start_year) < num(naissance.start_year)) {
+        add('avert', 'temps', `${nameOf(sid)} : règne commencé (${r.start_year}) avant sa naissance (${naissance.start_year}).`, sid);
+      }
+      if (mort && num(r.end_year) !== null && num(mort.start_year) !== null
+          && num(r.end_year) > num(mort.start_year)) {
+        add('avert', 'temps', `${nameOf(sid)} : règne fini (${r.end_year}) après sa mort (${mort.start_year}).`, sid);
+      }
+    }
+  }
+
+  // 12.3 Successions politiques — trous et chevauchements par entité gouvernée.
+  const polities = entities.filter(e => e.type === 'entite-politique');
+  for (const p of polities) {
+    const { anomalies } = await getDirigeants(exec, p.id);
+    for (const an of anomalies) add(an.type === 'chevauchement' ? 'avert' : 'info', 'succession', `${p.name} — ${an.detail}`, p.id);
+  }
+
+  // 12.4 Sanctuaire des mystères — une question protégée garde ≥ 2 lectures.
+  for (const e of entities.filter(x => x.type === 'question')) {
+    const data = parseJson(e.data) || {};
+    if (data.protege) {
+      const rs = readings.filter(r => r.question_id === e.id);
+      if (rs.length < 2) {
+        add('avert', 'mystere', `Mystère protégé « ${e.name} » : ${rs.length} lecture(s). Un mystère protégé doit conserver au moins deux lectures concurrentes.`, e.id);
+      }
+    }
+  }
+
+  const counts = {
+    erreur: issues.filter(i => i.severity === 'erreur').length,
+    avert: issues.filter(i => i.severity === 'avert').length,
+    info: issues.filter(i => i.severity === 'info').length,
+  };
+  return { counts, issues };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 13. STATISTIQUES — vue d'ensemble
+// ─────────────────────────────────────────────────────────────────────────
+
+async function getStats(exec) {
+  const byType = await q(exec, `SELECT type, COUNT(*) AS n FROM kg_entities GROUP BY type`);
+  const facts = await q(exec, `SELECT COUNT(*) AS n FROM kg_facts`);
+  const rels = await q(exec, `SELECT COUNT(*) AS n FROM kg_relations`);
+  const aliases = await q(exec, `SELECT COUNT(*) AS n FROM kg_aliases`);
+  return {
+    entitiesByType: byType.reduce((m, r) => (m[r.type] = Number(r.n), m), {}),
+    entities: byType.reduce((s, r) => s + Number(r.n), 0),
+    facts: Number((facts[0] || {}).n || 0),
+    relations: Number((rels[0] || {}).n || 0),
+    aliases: Number((aliases[0] || {}).n || 0),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 13b. ROUTAGE — mapping action→opération, partagé par les 2 backends
+// ─────────────────────────────────────────────────────────────────────────
+// Écrit une seule fois ; api/kg.js (Turso) et server.js (node:sqlite) l'appellent.
+
+function getCatalog() {
+  return {
+    entityTypes: ENTITY_TYPES, lieuScales: LIEU_SCALES, sourceRanks: SOURCE_RANKS,
+    factTypes: FACT_TYPES, relTypes: REL_TYPES, relInverse: REL_INVERSE,
+    statuses: STATUSES, disclosures: DISCLOSURES, precisions: PRECISIONS,
+    aliasStatuses: ALIAS_STATUSES,
+  };
+}
+
+async function readAction(exec, action, query) {
+  query = query || {};
+  switch (action || 'list') {
+    case 'catalog': return getCatalog();
+    case 'list': return { entities: await listEntities(exec, { type: query.type, search: query.search }) };
+    case 'entity': return { entity: await getEntity(exec, query.id) };
+    case 'dossier': return { dossier: await getDossier(exec, query.id) };
+    case 'chronologie': return { facts: await getChronologie(exec, {
+      fact_type: query.fact_type, era_id: query.era_id,
+      from_year: query.from_year, to_year: query.to_year, status: query.status }) };
+    case 'dirigeants': return { dirigeants: await getDirigeants(exec, query.id) };
+    case 'coherence': return { report: await getConsistencyReport(exec) };
+    case 'stats': return { stats: await getStats(exec) };
+    default: throw new KGError(`Action de lecture inconnue : ${action}`);
+  }
+}
+
+async function writeAction(exec, action, data) {
+  data = data || {};
+  switch (action) {
+    case 'save-entity': return { entity: await upsertEntity(exec, data) };
+    case 'delete-entity': return await deleteEntity(exec, data.id);
+    case 'save-alias': return await upsertAlias(exec, data);
+    case 'delete-alias': return await deleteAlias(exec, data.id);
+    case 'save-fact': return { fact: await upsertFact(exec, data) };
+    case 'delete-fact': return await deleteFact(exec, data.id);
+    case 'save-relation': return await upsertRelation(exec, data);
+    case 'delete-relation': return await deleteRelation(exec, data.id);
+    case 'save-reading': return await upsertReading(exec, data);
+    case 'delete-reading': return await deleteReading(exec, data.id);
+    default: throw new KGError(`Action d'écriture inconnue : ${action}`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 14. EXPORTS
+// ─────────────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // catalogues (exposés pour peupler les menus de l'UI)
+  ENTITY_TYPES, LIEU_SCALES, SOURCE_RANKS, FACT_TYPES, REL_TYPES, REL_INVERSE,
+  STATUSES, DISCLOSURES, PRECISIONS, ALIAS_STATUSES, ID_PREFIX,
+  KGError,
+  // schéma
+  initSchema, SCHEMA_STATEMENTS,
+  // entités
+  listEntities, getEntity, upsertEntity, deleteEntity, nextId,
+  // alias
+  getAliases, upsertAlias, deleteAlias,
+  // faits
+  getFact, upsertFact, deleteFact, validateFact,
+  // relations
+  upsertRelation, deleteRelation, validateRelation,
+  // lectures / mystères
+  getReadings, upsertReading, deleteReading,
+  // projections
+  getDossier, getChronologie, getDirigeants, getConsistencyReport, getStats,
+  // routage partagé
+  getCatalog, readAction, writeAction,
+  // utilitaires de date (réutilisés côté front si besoin)
+  formatYear, formatRange,
+};

--- a/lib/sqlite-adapter.js
+++ b/lib/sqlite-adapter.js
@@ -1,0 +1,29 @@
+'use strict';
+/*
+ * lib/sqlite-adapter.js — Adaptateur de stockage node:sqlite pour le graphe.
+ *
+ * Fournit `exec(sql, args) -> { rows }` attendu par lib/kg-core.js, adossé au
+ * module natif node:sqlite. C'est le miroir de développement (et de seed) de
+ * Turso : le MÊME SQL y tourne. Utilisé par server.js et scripts/migrate-kg.js.
+ */
+
+const { DatabaseSync } = require('node:sqlite');
+
+function createSqliteExec(target) {
+  const db = typeof target === 'string' ? new DatabaseSync(target) : target;
+  try { db.exec('PRAGMA journal_mode = WAL'); } catch { /* :memory: ou déjà posé */ }
+
+  const exec = async (sql, args = []) => {
+    if (!args || args.length === 0) {
+      const head = sql.trim().slice(0, 6).toUpperCase();
+      if (head === 'SELECT' || /RETURNING/i.test(sql)) return { rows: db.prepare(sql).all() };
+      db.exec(sql);
+      return { rows: [] };
+    }
+    return { rows: db.prepare(sql).all(...args) };
+  };
+
+  return { exec, db };
+}
+
+module.exports = { createSqliteExec };

--- a/lib/turso-adapter.js
+++ b/lib/turso-adapter.js
@@ -1,0 +1,59 @@
+'use strict';
+/*
+ * lib/turso-adapter.js — Adaptateur de stockage Turso (libSQL) pour le graphe.
+ *
+ * Fournit `exec(sql, args) -> { rows }` attendu par lib/kg-core.js, adossé à
+ * l'API HTTP Turso /v2/pipeline. Restaure le typage JS des cellules (entier,
+ * flottant, null) pour que les lignes soient IDENTIQUES à celles de node:sqlite.
+ * Utilisé en production par api/kg.js (et par la migration si les creds sont là).
+ */
+
+function toTursoArg(v) {
+  if (v === null || v === undefined) return { type: 'null' };
+  if (typeof v === 'boolean') return { type: 'integer', value: v ? 1 : 0 };
+  if (typeof v === 'number') {
+    return Number.isInteger(v) ? { type: 'integer', value: v } : { type: 'float', value: v };
+  }
+  return { type: 'text', value: String(v) };
+}
+
+function fromTursoCell(cell) {
+  if (!cell || cell.type === 'null') return null;
+  if (cell.type === 'integer' || cell.type === 'float') {
+    const n = Number(cell.value);
+    return Number.isNaN(n) ? cell.value : n;
+  }
+  return cell.value;
+}
+
+function createTursoExec(url, token) {
+  if (!url || !token) throw new Error('Turso non configuré (url / token manquants).');
+  const base = url.replace('libsql://', 'https://');
+
+  return async (sql, args) => {
+    const body = {
+      requests: [
+        { type: 'execute', stmt: { sql, args: (args || []).map(toTursoArg) } },
+        { type: 'close' },
+      ],
+    };
+    const res = await fetch(`${base}/v2/pipeline`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`Turso error: ${res.status}`);
+    const data = await res.json();
+    const result = data.results && data.results[0] && data.results[0].response && data.results[0].response.result;
+    if (!result) return { rows: [] };
+    const cols = result.cols.map(c => c.name);
+    const rows = result.rows.map(row => {
+      const obj = {};
+      row.forEach((cell, i) => { obj[cols[i]] = fromTursoCell(cell); });
+      return obj;
+    });
+    return { rows };
+  };
+}
+
+module.exports = { createTursoExec };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Site interactif de l'univers d'Hybélior (SPA vanilla JS).",
   "scripts": {
     "dev": "node server.js",
+    "kg:schema": "node -e \"const kg=require('./lib/kg-core.js'),fs=require('fs');const h='-- db/schema.sql — Schéma du graphe de connaissances (instantané régénéré par: npm run kg:schema).\\n-- SOURCE DE VÉRITÉ: lib/kg-core.js (SCHEMA_STATEMENTS). Même DDL Turso + node:sqlite.\\n\\n\\n';fs.mkdirSync('db',{recursive:true});fs.writeFileSync('db/schema.sql',h+kg.SCHEMA_STATEMENTS.map(s=>s.replace(/\\n\\s+/g,'\\n  ').trim()+';').join('\\n\\n')+'\\n')\"",
+    "kg:migrate": "node scripts/migrate-kg.js",
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,json,css}\"",
     "format:check": "prettier --check \"**/*.{js,json,css}\""

--- a/scripts/migrate-kg.js
+++ b/scripts/migrate-kg.js
@@ -1,0 +1,220 @@
+'use strict';
+/*
+ * scripts/migrate-kg.js — Seed du graphe de connaissances depuis les données
+ * chronologiques existantes (data/timeline-names.json).
+ *
+ * Transforme le corpus déjà à moitié structuré en graphe :
+ *   • ères                → entités type « ere » (id = slug d'origine)
+ *   • continents          → lieux (échelle continent) + noms historiques (alias datés)
+ *   • nations             → entités politiques + alias datés + fait « fondation »
+ *                           + relations situe-dans / pratique(religion) / capitale-de
+ *   • civilisations mortes → entités politiques + faits « fondation » et « chute »
+ *                           + relations situe-dans / succède-à
+ *
+ * Backend : Turso si TURSO_URL + TURSO_AUTH_TOKEN sont présents, sinon
+ * node:sqlite (local-kg.sqlite). Le MÊME cœur (lib/kg-core.js) traite les deux.
+ *
+ * Usage :  node scripts/migrate-kg.js [--reset]
+ *   --reset  vide d'abord les tables kg_* (seed propre).
+ */
+
+const path = require('path');
+const kg = require('../lib/kg-core.js');
+const { createSqliteExec } = require('../lib/sqlite-adapter.js');
+const { createTursoExec } = require('../lib/turso-adapter.js');
+const data = require('../data/timeline-names.json');
+
+const RESET = process.argv.includes('--reset');
+
+function pickExec() {
+  if (process.env.TURSO_URL && process.env.TURSO_AUTH_TOKEN) {
+    console.log('→ Backend : Turso');
+    return createTursoExec(process.env.TURSO_URL, process.env.TURSO_AUTH_TOKEN);
+  }
+  const file = path.join(__dirname, '..', 'local-kg.sqlite');
+  console.log('→ Backend : node:sqlite (' + file + ')');
+  return createSqliteExec(file).exec;
+}
+
+// Précision d'une date issue des chroniques : les temps très reculés sont des
+// estimations rituelles ; le reste, des années nettes.
+function datePrec(year) {
+  if (year === null || year === undefined) return { precision: 'annee', circa: 0 };
+  if (year < -1000) return { precision: 'estimation', circa: 1 };
+  return { precision: 'annee', circa: 0 };
+}
+
+function truncate(s, n) {
+  if (!s) return null;
+  return s.length > n ? s.slice(0, n - 1) + '…' : s;
+}
+
+(async () => {
+  const exec = pickExec();
+  await kg.initSchema(exec);
+
+  if (RESET) {
+    for (const t of ['kg_readings', 'kg_relations', 'kg_facts', 'kg_aliases', 'kg_entities', 'kg_audit']) {
+      await exec(`DELETE FROM ${t}`, []);
+    }
+    console.log('⌫ tables kg_* vidées (--reset)');
+  }
+
+  // Index (type|name) → id, pour l'idempotence et la résolution des relations.
+  const index = new Map();
+  const key = (type, name) => `${type}|${name}`;
+  for (const row of (await exec(`SELECT id, type, name FROM kg_entities`, [])).rows) {
+    index.set(key(row.type, row.name), row.id);
+  }
+
+  async function ensure(type, name, extra) {
+    const k = key(type, name);
+    if (index.has(k)) return index.get(k);
+    const e = await kg.upsertEntity(exec, Object.assign({ type, name }, extra || {}));
+    index.set(k, e.id);
+    return e.id;
+  }
+
+  const td = data.timelineData;
+  let counts = { eras: 0, continents: 0, aliases: 0, nations: 0, civs: 0, religions: 0, facts: 0, relations: 0, capitals: 0 };
+
+  // ── Source de provenance des faits migrés ─────────────────────────────
+  const srcId = await ensure('source', 'Chroniques d’Hybélior (chronologie canonique)', {
+    summary: 'Chronologie et noms historiques agrégés — provenance des faits migrés.',
+    data: { rang: 'chronique-interne' },
+  });
+
+  // ── Ères (id = slug d'origine, pour préserver les références era_id) ───
+  for (const era of td.eras) {
+    await kg.upsertEntity(exec, {
+      id: era.id, type: 'ere', name: era.name, summary: era.description,
+      data: { startYear: era.startYear, endYear: era.endYear },
+    });
+    counts.eras++;
+  }
+
+  // ── Continents (lieux) + noms historiques datés (alias) ───────────────
+  const continentIdByName = {};
+  for (const ct of td.continentTimelines) {
+    const id = await ensure('lieu', ct.currentName, { data: { echelle: 'continent' } });
+    continentIdByName[ct.currentName] = id;
+    counts.continents++;
+    for (const seg of (ct.timeline || [])) {
+      if (!seg.name) continue;
+      const isCurrent = seg.name === ct.currentName;
+      await kg.upsertAlias(exec, {
+        entity_id: id, value: seg.name,
+        alias_status: isCurrent ? 'visible' : 'predecessor',
+        from_year: seg.startYear, to_year: seg.endYear,
+      });
+      counts.aliases++;
+    }
+  }
+
+  // ── Nations (entités politiques) ──────────────────────────────────────
+  for (const c of td.countries) {
+    const polId = await ensure('entite-politique', c.currentName, {
+      data: { continent: c.continent || null, religion: c.religion || null },
+    });
+    counts.nations++;
+
+    const segs = (c.timeline || []).slice().sort((a, b) => (a.startYear ?? 0) - (b.startYear ?? 0));
+
+    // Alias datés (noms successifs de la lignée politique)
+    for (const seg of segs) {
+      if (!seg.name) continue;
+      const isCurrent = seg.name === c.currentName;
+      await kg.upsertAlias(exec, {
+        entity_id: polId, value: seg.name,
+        alias_status: isCurrent ? 'visible' : 'predecessor',
+        from_year: seg.startYear, to_year: seg.endYear,
+        meaning: truncate([seg.type, seg.notes].filter(Boolean).join(' — '), 240),
+      });
+      counts.aliases++;
+    }
+
+    // Fait « fondation » au plus ancien segment
+    if (segs.length && segs[0].startYear !== undefined) {
+      const p = datePrec(segs[0].startYear);
+      await kg.upsertFact(exec, {
+        fact_type: 'fondation', subject_id: polId,
+        start_year: segs[0].startYear, start_precision: p.precision, start_circa: p.circa,
+        era_id: segs[0].era || null, label: segs[0].name, source_id: srcId,
+      });
+      counts.facts++;
+    }
+
+    // Relation situe-dans → continent
+    if (c.continent && continentIdByName[c.continent]) {
+      await kg.upsertRelation(exec, { rel_type: 'situe-dans', from_id: polId, to_id: continentIdByName[c.continent], source_id: srcId });
+      counts.relations++;
+    }
+
+    // Relation pratique → religion
+    if (c.religion) {
+      const relId = await ensure('religion', c.religion, {});
+      counts.religions = Object.keys(index).length; // approximé plus bas
+      await kg.upsertRelation(exec, { rel_type: 'pratique', from_id: polId, to_id: relId, source_id: srcId });
+      counts.relations++;
+    }
+
+    // Capitale actuelle → lieu (cité) + relation capitale-de
+    const lastCap = [...segs].reverse().find(s => s.capital);
+    if (lastCap && lastCap.capital) {
+      const capId = await ensure('lieu', lastCap.capital, { data: { echelle: 'cite' } });
+      await kg.upsertRelation(exec, { rel_type: 'capitale-de', from_id: capId, to_id: polId, start_year: lastCap.startYear, source_id: srcId });
+      counts.capitals++;
+      counts.relations++;
+    }
+  }
+
+  // ── Civilisations disparues (entités politiques + fondation/chute) ─────
+  const pendingSuccessions = [];
+  for (const civ of (td.civilisationsDisparues || [])) {
+    const civId = await ensure('entite-politique', civ.name, {
+      summary: truncate(civ.notes, 240),
+      data: { continent: civ.continent || null, disparue: true, type: civ.type || null },
+    });
+    counts.civs++;
+
+    if (civ.startYear !== undefined) {
+      const p = datePrec(civ.startYear);
+      await kg.upsertFact(exec, { fact_type: 'fondation', subject_id: civId, start_year: civ.startYear, start_precision: p.precision, start_circa: p.circa, source_id: srcId });
+      counts.facts++;
+    }
+    if (civ.endYear !== undefined) {
+      const p = datePrec(civ.endYear);
+      await kg.upsertFact(exec, { fact_type: 'chute', subject_id: civId, start_year: civ.endYear, start_precision: p.precision, start_circa: p.circa, source_id: srcId });
+      counts.facts++;
+    }
+    if (civ.continent && continentIdByName[civ.continent]) {
+      await kg.upsertRelation(exec, { rel_type: 'situe-dans', from_id: civId, to_id: continentIdByName[civ.continent], source_id: srcId });
+      counts.relations++;
+    }
+    if (civ.successeur) pendingSuccessions.push({ civName: civ.name, successorName: civ.successeur });
+  }
+
+  // Successions (2e passe : le successeur doit exister)
+  for (const s of pendingSuccessions) {
+    const civId = index.get(key('entite-politique', s.civName));
+    const succId = index.get(key('entite-politique', s.successorName));
+    if (civId && succId) {
+      await kg.upsertRelation(exec, { rel_type: 'succede-a', from_id: succId, to_id: civId, source_id: srcId });
+      counts.relations++;
+    }
+  }
+
+  // Compter les religions réellement créées
+  counts.religions = [...index.keys()].filter(k => k.startsWith('religion|')).length;
+
+  const stats = await kg.getStats(exec);
+  const rep = await kg.getConsistencyReport(exec);
+  console.log('\n✔ Migration terminée');
+  console.log('  créé :', JSON.stringify(counts));
+  console.log('  graphe :', JSON.stringify(stats));
+  console.log('  cohérence :', JSON.stringify(rep.counts));
+  if (rep.counts.erreur) {
+    console.log('  ⚠ erreurs de cohérence :');
+    rep.issues.filter(i => i.severity === 'erreur').slice(0, 10).forEach(i => console.log('    -', i.message));
+  }
+})().catch(e => { console.error('ÉCHEC migration:', e); process.exit(1); });

--- a/server.js
+++ b/server.js
@@ -1,13 +1,26 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const kg = require('./lib/kg-core.js');
+const { createSqliteExec } = require('./lib/sqlite-adapter.js');
 
 const PORT = process.env.PORT || 3001;
 const DB_FILE = path.join(__dirname, 'local-db.json');
 const HISTORY_FILE = path.join(__dirname, 'local-history.json');
 const BORDERS_FILE = path.join(__dirname, 'local-borders.json');
+const KG_DB_FILE = path.join(__dirname, 'local-kg.sqlite');
 const LORE_ROOT = path.join(__dirname, 'Docs', 'Lore');
 const EDITOR_PASSWORD = process.env.EDITOR_PASSWORD || 'local';
+
+// ── Graphe de connaissances : adaptateur node:sqlite (miroir dev de Turso) ──
+// Le MÊME cœur (lib/kg-core.js) tourne ici et sur Turso en production.
+let kgExec = null;
+let kgSchemaReady = false;
+async function ensureKgSchema() {
+  if (!kgExec) kgExec = createSqliteExec(KG_DB_FILE).exec;
+  if (!kgSchemaReady) { await kg.initSchema(kgExec); kgSchemaReady = true; }
+  return kgExec;
+}
 
 // ── Local DB (dev fallback for /api/overrides) ──────────────
 
@@ -280,6 +293,41 @@ const server = http.createServer(async (req, res) => {
         } catch (err) {
             res.writeHead(400, { 'Content-Type': 'application/json' });
             return res.end(JSON.stringify({ error: err.message }));
+        }
+    }
+
+    // ── API: /api/kg (graphe de connaissances) ────────────────
+    if (pathname === '/api/kg') {
+        try {
+            await ensureKgSchema();
+            if (req.method === 'GET') {
+                if (req.headers['x-editor-password'] !== EDITOR_PASSWORD) {
+                    res.writeHead(403, { 'Content-Type': 'application/json' });
+                    return res.end(JSON.stringify({ error: 'Mot de passe requis (header X-Editor-Password)' }));
+                }
+                const query = Object.fromEntries(url.searchParams.entries());
+                const out = await kg.readAction(kgExec, query.action || 'list', query);
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                return res.end(JSON.stringify(out));
+            }
+            if (req.method === 'POST') {
+                const { password, action, data } = await parseBody(req);
+                if (password !== EDITOR_PASSWORD) {
+                    res.writeHead(403, { 'Content-Type': 'application/json' });
+                    return res.end(JSON.stringify({ error: 'Mot de passe incorrect' }));
+                }
+                const out = await kg.writeAction(kgExec, action, data);
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                return res.end(JSON.stringify(out));
+            }
+            res.writeHead(405, { 'Content-Type': 'application/json' });
+            return res.end(JSON.stringify({ error: 'Method not allowed' }));
+        } catch (err) {
+            const code = err && err.code ? err.code : 'error';
+            const status = (code === 'validation' || code === 'ref' || code === 'referenced') ? 400
+                : code === 'not-found' ? 404 : 500;
+            res.writeHead(status, { 'Content-Type': 'application/json' });
+            return res.end(JSON.stringify({ error: err.message, code }));
         }
     }
 


### PR DESCRIPTION
## Objectif

Faire du **site lui-même la source de vérité unique** de l'univers d'Hybélior (outil privé, pour l'auteur). Chaque information — personne, empire, ville, événement, concept, religion, espèce, objet — n'existe qu'à **un seul endroit** et est *projetée* partout ailleurs (fiche, chronologie, liste de dirigeants, cohérence). La non-duplication devient structurelle, pas une discipline.

Pas d'Obsidian : le magasin de vérité est la base de données du site (Turso en prod, `node:sqlite` en dev), l'Atelier est l'éditeur **et** le lecteur.

## Architecture

```
   /atelier.html  ──▶  /api/kg  ──▶  Turso (prod) / node:sqlite (dev)  ──▶  projections
   (éditeur privé)      (lib/kg-core.js — même SQL des deux côtés)
```

- **`lib/kg-core.js`** — le cœur, backend-agnostique. Schéma, catalogues fermés, validation, cohérence, projections. Toute la logique écrite **une seule fois** ; les adaptateurs ne font que du stockage.
- **`lib/turso-adapter.js`** / **`lib/sqlite-adapter.js`** — deux stockages, un seul dialecte SQL (Turso est un fork de SQLite → le même SQL tourne des deux côtés).
- **`api/kg.js`** (Vercel/Turso) et **`server.js`** (dev/node:sqlite) partagent le cœur ; accès privé par mot de passe (`X-Editor-Password` en lecture, corps en écriture).

## Modèle de données

- **Identité stable** : id opaque et permanent (`per-0001`, `pol-0042`) distinct du nom d'affichage — les renommages ne cassent **aucune** référence (résout Velkar→Verkan, homonymies).
- **Noms datés** (`kg_aliases`) : période de validité + statut (`visible`, `predecessor`, `vanished`…).
- **Faits datés** (`kg_facts`) : naissance, mort, règne, fondation, chute… avec date-objet (année, précision variable, « circa »), ordre de départage (`seq`), provenance (`source_id`) et statut épistémique.
- **Relations** (`kg_relations`) typées, dirigées, saisies une fois (arête inverse calculée à la projection).
- **Mystères protégés** : entités `question` à **lectures concurrentes** (`kg_readings`), jamais aplaties en un fait unique.
- **Statut épistémique** partout : `canon` › `lecture-disputee` › `rumeur` › `retconne`.

## Projections (une info écrite une fois, affichée partout)

- **Fiche** (dossier) : alias, faits, relations, lectures agrégés à la lecture.
- **Chronologie** : tous les faits triés par (date, seq), double calendrier.
- **Dirigeants** : **calculés** depuis les faits « regne » (jamais maintenus à la main), avec détection des trous et chevauchements de succession.
- **Cohérence** : scan global — intégrité référentielle, cohérence de vie (nul ne meurt avant de naître), continuité des successions, provenance du canon, sanctuaire des mystères. Une contradiction est *visible*, jamais silencieuse.

## Migration

`scripts/migrate-kg.js` sème le graphe depuis `data/timeline-names.json` :
**98 entités, 76 faits, 87 relations, 193 noms datés — cohérence 0 erreur**.

## Vérifications

- Cœur validé contre `node:sqlite` (projections + garde-fous + détection de contradictions).
- Aller-retour HTTP complet sur `/api/kg` (CRUD + projections + rejets de validation).
- Migration exécutée : rapport de cohérence propre.
- **E2E navigateur (Playwright/Chromium)** : verrou, liste (98 entités), fiche d'Altram (4 noms datés + fait + relations), chronologie (76 faits), dirigeants, cohérence (0/0/0), création d'entité depuis l'UI — **0 erreur console**.
- `eslint` : 0 erreur.

## Fichiers

`lib/kg-core.js`, `lib/turso-adapter.js`, `lib/sqlite-adapter.js`, `api/kg.js`, `server.js`, `atelier.html`, `js/atelier.js`, `scripts/migrate-kg.js`, `db/schema.sql`, `db/README.md`, `package.json`, `.gitignore`.

## Utilisation

```bash
npm run dev            # site + /api/kg (node:sqlite)
npm run kg:migrate     # seed [--reset]
# http://localhost:3001/atelier.html — mot de passe : EDITOR_PASSWORD (défaut « local »)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e8FqmkmGYdnxqJE3Thbhj

---
_Generated by [Claude Code](https://claude.ai/code/session_013e8FqmkmGYdnxqJE3Thbhj)_