### PR TITLE
Atelier : consultation libre depuis l'accueil, mot de passe seulement pour éditer

### DIFF
--- a/atelier.html
+++ b/atelier.html
@@ -47,6 +47,10 @@
     .badge.st-canon { color: var(--ok); } .badge.st-rumeur { color: var(--faint); }
     .badge.st-lecture-disputee { color: var(--warn); } .badge.st-retconne { color: var(--err); text-decoration: line-through; }
     .muted { color: var(--dim); } .faint { color: var(--faint); }
+    /* Mode consultation (défaut) vs édition : les contrôles d'édition sont
+       masqués tant qu'on n'a pas déverrouillé avec le mot de passe. */
+    body:not(.can-edit) .edit-only { display: none !important; }
+    #btnLock.on { color: var(--ok); border-color: var(--ok); }
     .row { display: flex; gap: 8px; align-items: center; }
     .grow { flex: 1; }
 
@@ -163,7 +167,7 @@
     <h1>Atelier · <span class="g">Graphe canonique d'Hybélior</span></h1>
     <div id="stats" class="muted"></div>
     <button id="btnCoherence" class="ghost" title="Vérifier la cohérence">✓ Cohérence</button>
-    <button id="btnLogout" class="ghost" title="Oublier le mot de passe">⏻</button>
+    <button id="btnLock" class="ghost" title="Déverrouiller l'édition">🔒 Modifier</button>
   </header>
 
   <main>
@@ -171,7 +175,7 @@
       <div class="tools">
         <input id="search" type="search" placeholder="Rechercher (nom ou nom historique)…" autocomplete="off" />
         <div id="typeFilter"></div>
-        <button id="btnNew" class="primary">＋ Nouvelle entité</button>
+        <button id="btnNew" class="primary edit-only">＋ Nouvelle entité</button>
       </div>
       <div id="entityList"></div>
     </aside>

--- a/js/atelier.js
+++ b/js/atelier.js
@@ -61,11 +61,19 @@ function toast(msg, isErr) {
 }
 async function guard(fn) { try { return await fn(); } catch (e) { if (e.auth) askPassword(); else toast(e.message, true); throw e; } }
 
-// ── Petit mot de passe (débloque l'édition ; la lecture reste ouverte) ─────────
-function askPassword() {
+// ── Consultation libre ; le mot de passe ne sert qu'à DÉBLOQUER l'édition ──────
+let _pwOnOk = null;
+function setEdit(on) {
+  document.body.classList.toggle('can-edit', on);
+  const b = $('#btnLock');
+  if (on) { b.textContent = '🔓 Verrouiller'; b.classList.add('on'); b.title = 'Repasser en lecture seule'; }
+  else { b.textContent = '🔒 Modifier'; b.classList.remove('on'); b.title = "Déverrouiller l'édition"; }
+}
+function askPassword(onOk) {
+  _pwOnOk = typeof onOk === 'function' ? onOk : null;
   openModal(h('div', {},
-    h('h2', { text: 'Mot de passe' }),
-    h('p', { class: 'muted', text: 'Entre le mot de passe pour éditer le graphe.' }),
+    h('h2', { text: 'Déverrouiller l’édition' }),
+    h('p', { class: 'muted', text: 'La consultation est libre. Entre le mot de passe pour pouvoir modifier.' }),
     h('input', { id: 'pwField', type: 'password', placeholder: 'Mot de passe', onkeydown: (e) => { if (e.key === 'Enter') submitPw(); } }),
     h('div', { class: 'actions' }, h('button', { class: 'primary', onclick: submitPw, text: 'Entrer' })),
   ));
@@ -76,7 +84,8 @@ async function submitPw() {
   try {
     const r = await fetch('/api/auth', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ password: pw }) });
     if (!r.ok) return toast('Mot de passe incorrect', true);
-    KG.pw = pw; sessionStorage.setItem('kgpw', pw); closeModal(); boot();
+    KG.pw = pw; sessionStorage.setItem('kgpw', pw); setEdit(true); closeModal();
+    const cb = _pwOnOk; _pwOnOk = null; if (cb) cb();
   } catch { toast('Erreur d’authentification', true); }
 }
 
@@ -191,8 +200,8 @@ async function renderFiche() {
         h('span', { class: 'badge st-' + e.status, text: e.status }), ' ',
         h('span', { class: 'faint', text: '· ' + e.id }))),
     h('div', { class: 'row' },
-      h('button', { onclick: () => entityForm(e), text: '✎ Éditer' }),
-      h('button', { class: 'danger', onclick: () => deleteEntity(e), text: '🗑' }))));
+      h('button', { class: 'edit-only', onclick: () => entityForm(e), text: '✎ Éditer' }),
+      h('button', { class: 'danger edit-only', onclick: () => deleteEntity(e), text: '🗑' }))));
 
   if (e.summary) view.append(h('p', { class: 'muted', text: e.summary }));
   if (e.body) view.append(h('div', { class: 'card', style: 'white-space:pre-wrap; margin-bottom:22px', text: e.body }));
@@ -247,15 +256,15 @@ async function renderFiche() {
 
 function section(title, onAdd, rows) {
   return h('div', { class: 'section' },
-    h('h3', {}, h('span', { text: title }), onAdd ? h('button', { class: 'ghost', onclick: onAdd, text: '＋ ajouter' }) : null),
+    h('h3', {}, h('span', { text: title }), onAdd ? h('button', { class: 'ghost edit-only', onclick: onAdd, text: '＋ ajouter' }) : null),
     ...rows);
 }
 function item(when, whatKids, onDel, onEdit) {
   return h('div', { class: 'item' },
     h('div', { class: 'when' }, when),
     h('div', { class: 'what' }, ...(Array.isArray(whatKids) ? whatKids : [whatKids])),
-    onEdit ? h('span', { class: 'x', onclick: onEdit, text: '✎' }) : null,
-    onDel ? h('span', { class: 'x', onclick: onDel, text: '✕' }) : null);
+    onEdit ? h('span', { class: 'x edit-only', onclick: onEdit, text: '✎' }) : null,
+    onDel ? h('span', { class: 'x edit-only', onclick: onDel, text: '✕' }) : null);
 }
 function emptyRow(txt) { return h('div', { class: 'item' }, h('div', { class: 'faint', text: txt })); }
 function yearsLabel(a, b) {
@@ -555,7 +564,10 @@ $('#search').addEventListener('input', (e) => { S.search = e.target.value.trim()
 $('#btnNew').addEventListener('click', () => entityForm(null));
 $('#btnCoherence').addEventListener('click', () => { S.tab = 'coherence'; document.querySelectorAll('#tabs .tab').forEach(t => t.classList.toggle('active', t.dataset.tab === 'coherence')); renderView(); });
 
-$('#btnLogout').addEventListener('click', () => { sessionStorage.removeItem('kgpw'); KG.pw = ''; askPassword(); });
+$('#btnLock').addEventListener('click', () => {
+  if (document.body.classList.contains('can-edit')) { KG.pw = ''; sessionStorage.removeItem('kgpw'); setEdit(false); }
+  else askPassword();
+});
 
 async function boot() {
   S.catalog = (await guard(() => KG.get('catalog')));
@@ -564,4 +576,4 @@ async function boot() {
   renderView();
 }
 
-(function init() { if (KG.pw) boot(); else askPassword(); })();
+(function init() { boot(); if (KG.pw) setEdit(true); })();

--- a/pages/accueil.html
+++ b/pages/accueil.html
@@ -99,6 +99,15 @@
         <p>Filiation des peuples — des empires fondateurs aux nations actuelles, à travers les 10 grandes lignées qui structurent l'histoire d'Hybelior.</p>
     </a>
 
+    <a href="/atelier.html" class="card">
+        <svg class="card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="6" cy="6" r="2.5"/><circle cx="18" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/>
+            <line x1="7.6" y1="7.6" x2="10.6" y2="16"/><line x1="16.4" y1="7.6" x2="13.4" y2="16"/><line x1="8.5" y1="6" x2="15.5" y2="6"/>
+        </svg>
+        <h3>Atelier du monde</h3>
+        <p>Le graphe canonique — entités, chronologie, dirigeants, arbres généalogiques, cohérence. Consultation libre ; un mot de passe pour éditer.</p>
+    </a>
+
 </div>
 
 <script>


### PR DESCRIPTION
Sur demande : **on consulte l'Atelier librement (accessible depuis l'accueil, sans mot de passe) ; le mot de passe ne sert qu'à modifier.**

## Changements

- **Accès depuis l'accueil** : nouvelle carte **« Atelier du monde »** dans la grille de la page d'accueil, vers `/atelier.html`.
- **Ouverture en lecture, sans mot de passe** : plus de verrou à l'entrée — l'Atelier affiche directement le graphe (les données de base sont statiques, servies sans Turso).
- **Édition masquée jusqu'au déverrouillage** : les contrôles d'édition (Nouvelle entité, Éditer, ajouter, supprimer) sont cachés en mode lecture. Le bouton **« 🔒 Modifier »** demande le mot de passe une fois, révèle l'édition, et bascule en **« 🔓 Verrouiller »** pour repasser en lecture. L'écriture reste protégée **côté serveur** (`/api/kg` POST + `EDITOR_PASSWORD`).

## Vérifié (Playwright/Chromium)

- Lecture **sans mot de passe** : 117 entités chargées, **aucune modale** à l'ouverture.
- Boutons d'édition **masqués en lecture**, **visibles après déverrouillage**, **re-masqués** au re-verrouillage.
- **Création en mode édition** OK ; lien **Atelier présent sur l'accueil**.
- **0 erreur console** ; `eslint` 0.

## Fichiers

`pages/accueil.html` (carte de lien), `atelier.html` (bouton « Modifier » + masquage CSS), `js/atelier.js` (ouverture en lecture, bascule lecture/édition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e8FqmkmGYdnxqJE3Thbhj

---
_Generated by [Claude Code](https://claude.ai/code/session_013e8FqmkmGYdnxqJE3Thbhj)_